### PR TITLE
Admin must approve Artists new Campaigns

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,11 +16,9 @@ gem 'devise'
 gem 'omniauth-facebook'
 gem 'pundit'
 gem 'omniauth-google-oauth2', '~> 0.5.3'
-
-## CSS Frameworks and support
-## MUI is 'almost' like Bootstrap but without jQuery. Allegedly ;-) 
 gem 'mui-sass', '~> 0.9.35'
 gem 'font-awesome-sass', '~> 5.0', '>= 5.0.13'
+gem 'state_machines-activerecord'
 
 group :development, :test do
   gem 'chromedriver-helper'
@@ -34,6 +32,7 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'coveralls', require: false
   gem 'pundit-matchers', '~> 1.6.0'
+  gem 'state_machines-rspec'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,10 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.1)
@@ -303,6 +307,17 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    state_machines (0.5.0)
+    state_machines-activemodel (0.5.1)
+      activemodel (>= 4.1, < 6.0)
+      state_machines (>= 0.5.0)
+    state_machines-activerecord (0.5.1)
+      activerecord (>= 4.1, < 6.0)
+      state_machines-activemodel (>= 0.5.0)
+    state_machines-rspec (0.5.0)
+      activesupport
+      rspec (~> 3.3)
+      state_machines
     temple (0.8.0)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
@@ -361,6 +376,8 @@ DEPENDENCIES
   shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
+  state_machines-activerecord
+  state_machines-rspec
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -2,7 +2,11 @@ class CampaignsController < ApplicationController
   before_action :authenticate_user!, only: [:create]
 
   def index
-    @campaigns = Campaign.all
+    if user_signed_in? && current_user.admin?
+      @campaigns = Campaign.all
+    else
+      @campaigns = Campaign.with_state(:accepted)
+    end
   end
 
   def new

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -24,19 +24,19 @@ class CampaignsController < ApplicationController
     @campaign = Campaign.find(params[:id])
   end
 
-  def update
-    campaign = Campaign.find(params[:id])
-    if params[:event] == 'admin_accepts_campaign'
-      campaign.admin_accepts_campaign!
-    end
-  end
-  
-  #def admin_accepts_campaign
+  #def update
   #  campaign = Campaign.find(params[:id])
   #  if params[:event] == 'admin_accepts_campaign'
   #    campaign.admin_accepts_campaign!
   #  end
   #end
+  
+  def admin_accepts_campaign
+    @campaign = Campaign.find(params[:id])
+    if params[:event] == 'admin_accepts_campaign'
+      @campaign.admin_accepts_campaign!
+    end
+  end
 
 private
 

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -23,6 +23,13 @@ class CampaignsController < ApplicationController
     @campaign = Campaign.find(params[:id])
   end
 
+
+  def admin_accept
+    @campaign = Campaign.find(params[:id])
+      if params[:event] == 'admin_accepts_campaign'
+        @campaign.admin_accepts_campaign
+      end
+  end
 private
 
   def campaign_params

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -23,10 +23,19 @@ class CampaignsController < ApplicationController
     @campaign = Campaign.find(params[:id])
   end
 
-  def admin_accepts_campaign
-    @campaign = Campaign.find(params[:id])
-    @campaign.admin_accepts_campaign!
+  def update
+    campaign = Campaign.find(params[:id])
+    if params[:event] == 'admin_accepts_campaign'
+      campaign.admin_accepts_campaign!
+    end
   end
+  
+  #def admin_accepts_campaign
+  #  campaign = Campaign.find(params[:id])
+  #  if params[:event] == 'admin_accepts_campaign'
+  #    campaign.admin_accepts_campaign!
+  #  end
+  #end
 
 private
 

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -26,6 +26,6 @@ class CampaignsController < ApplicationController
 private
 
   def campaign_params
-    params.require(:campaign).permit(:title, :description, :location, :image)
+    params.require(:campaign).permit(:title, :description, :location, :image, :state)
   end
 end

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -24,19 +24,14 @@ class CampaignsController < ApplicationController
     @campaign = Campaign.find(params[:id])
   end
 
-  #def update
-  #  campaign = Campaign.find(params[:id])
-  #  if params[:event] == 'admin_accepts_campaign'
-  #    campaign.admin_accepts_campaign!
-  #  end
-  #end
-  
-  def admin_accepts_campaign
-    @campaign = Campaign.find(params[:id])
-    if params[:event] == 'admin_accepts_campaign'
-      @campaign.admin_accepts_campaign!
-    end
+  def update
+   campaign = Campaign.find(params[:id])
+   if params[:event] == 'accept'
+     campaign.accept
+     redirect_to campaign, notice: 'This campaign is now live!'
+   end
   end
+
 
 private
 

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -23,13 +23,11 @@ class CampaignsController < ApplicationController
     @campaign = Campaign.find(params[:id])
   end
 
-
-  def admin_accept
+  def admin_accepts_campaign
     @campaign = Campaign.find(params[:id])
-      if params[:event] == 'admin_accepts_campaign'
-        @campaign.admin_accepts_campaign
-      end
+    @campaign.admin_accepts_campaign!
   end
+
 private
 
   def campaign_params

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -1,6 +1,13 @@
 class Campaign < ApplicationRecord
-    validates_presence_of :title, :description, :location 
+    validates_presence_of :title, :description, :location, :state
     
     belongs_to :user
     has_one_attached :image
+
+    state_machine :state, initial: :pending do 
+
+        event :admin_accepts_campaign do 
+            transition :pending => :accepted
+        end
+    end
 end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -1,13 +1,12 @@
 class Campaign < ApplicationRecord
-    validates_presence_of :title, :description, :location, :state
-    
-    belongs_to :user
-    has_one_attached :image
+  validates_presence_of :title, :description, :location, :state
 
-    state_machine :state, initial: :pending do 
+  belongs_to :user
+  has_one_attached :image
 
-        event :admin_accepts_campaign do 
-            transition :pending => :accepted
-        end
+  state_machine :state, initial: :pending do
+    event :accept do
+      transition pending: :accepted
     end
+  end
 end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -3,12 +3,12 @@ class Campaign < ApplicationRecord
 
   belongs_to :user
   has_one_attached :image
+  has_many :tickets
+  accepts_nested_attributes_for :tickets
 
   state_machine :state, initial: :pending do
     event :accept do
       transition pending: :accepted
     end
   end
-
-  accepts_nested_attributes_for :tickets
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: [:facebook, :google_oauth2]
-  enum role: { artist: 0, fan: 1 }
+  enum role: { artist: 0, fan: 1, admin: 9 }
 
   def set_default_role
     self.role ||= :fan

--- a/app/policies/campaign_policy.rb
+++ b/app/policies/campaign_policy.rb
@@ -1,11 +1,11 @@
 class CampaignPolicy < ApplicationPolicy
 
     def new?
-        user.artist?
+        !user.fan?
     end
 
     def create?
-        user.artist?
+        new?
     end
 
     def index?
@@ -14,6 +14,5 @@ class CampaignPolicy < ApplicationPolicy
 
     def show?
         true
-    end
-    
+    end    
 end

--- a/app/views/campaigns/_index_detail.html.haml
+++ b/app/views/campaigns/_index_detail.html.haml
@@ -17,6 +17,9 @@
             Tickets Sold
         %span.reserved 80%
         %span.reserve
-            Reserve Spot
-            %svg{:style => "enable-background:new 0 0 24 24;", :version => "1.1", :viewbox => "0 0 24 24", :x => "0px", "xml:space" => "preserve", :xmlns => "http://www.w3.org/2000/svg", "xmlns:xlink" => "http://www.w3.org/1999/xlink", :y => "0px"}
-            %polygon{:fill => "rgb(240,215,93)", :points => "24,12 13.5,1.5 11.1,3.8 17.9,10.6 0,10.6 0,13.9 17.4,13.9 11.1,20.2 13.5,22.5 21.7,14.3 21.7,14.3"}
+            - if campaign.pending?
+                NOT ACCEPTED
+            - else
+                Reserve Spot
+                %svg{:style => "enable-background:new 0 0 24 24;", :version => "1.1", :viewbox => "0 0 24 24", :x => "0px", "xml:space" => "preserve", :xmlns => "http://www.w3.org/2000/svg", "xmlns:xlink" => "http://www.w3.org/1999/xlink", :y => "0px"}
+                    %polygon{:fill => "rgb(240,215,93)", :points => "24,12 13.5,1.5 11.1,3.8 17.9,10.6 0,10.6 0,13.9 17.4,13.9 11.1,20.2 13.5,22.5 21.7,14.3 21.7,14.3"}

--- a/app/views/campaigns/index.html.haml
+++ b/app/views/campaigns/index.html.haml
@@ -7,5 +7,8 @@
         = truncate(campaign.description, length: 100) { link_to ' (more)', campaign_path(campaign)} 
     %p
         = campaign.location
+    
+    = button_to 'Reject', '#'
+    = button_to 'Accept', campaign_path(campaign, event: :admin_accepts_campaign), method: :admin_accept, remote: true, id: 'accept'
     %button{type: "button"} Reject
     %button{type: "button"} Accept

--- a/app/views/campaigns/index.html.haml
+++ b/app/views/campaigns/index.html.haml
@@ -9,6 +9,4 @@
         = campaign.location
     
     = button_to 'Reject', '#'
-    = button_to 'Accept', campaign_path(campaign, event: :admin_accepts_campaign), method: :admin_accept, remote: true, id: 'accept'
-    %button{type: "button"} Reject
-    %button{type: "button"} Accept
+    = button_to 'Accept', campaigns_path(@campaign, event: :admin_accepts_campaign), remote: true, method: :put

--- a/app/views/campaigns/index.html.haml
+++ b/app/views/campaigns/index.html.haml
@@ -1,7 +1,12 @@
 - @campaigns.each do |campaign|
     %h1
         = link_to campaign.title, campaign_path(campaign)
+    - if campaign.image.attached?
+        = image_tag article.image
     %p
         = truncate(campaign.description, length: 100) { link_to ' (more)', campaign_path(campaign)} 
     %p
         = campaign.location
+    - if current_user&.admin? && campaign.state == 'pending'
+        %button{type: "button"} Reject
+        %button{type: "button"} Accept

--- a/app/views/campaigns/index.html.haml
+++ b/app/views/campaigns/index.html.haml
@@ -2,11 +2,10 @@
     %h1
         = link_to campaign.title, campaign_path(campaign)
     - if campaign.image.attached?
-        = image_tag article.image
+        = image_tag campaign.image
     %p
         = truncate(campaign.description, length: 100) { link_to ' (more)', campaign_path(campaign)} 
     %p
         = campaign.location
-    - if current_user&.admin? && campaign.state == 'pending'
-        %button{type: "button"} Reject
-        %button{type: "button"} Accept
+    %button{type: "button"} Reject
+    %button{type: "button"} Accept

--- a/app/views/campaigns/index.html.haml
+++ b/app/views/campaigns/index.html.haml
@@ -9,4 +9,4 @@
         = campaign.location
     
     = button_to 'Reject', '#'
-    = button_to 'Accept', campaigns_path(@campaign, event: :admin_accepts_campaign), remote: true, method: :put
+    = button_to 'Accept', campaign_path(campaign, event: :admin_accepts_campaign), method: :put, remote: true

--- a/app/views/campaigns/index.html.haml
+++ b/app/views/campaigns/index.html.haml
@@ -4,3 +4,4 @@
         .mui-row
             - section.each do |campaign|
                 = render partial: 'index_detail', locals: {campaign: campaign}
+    

--- a/app/views/campaigns/index.html.haml
+++ b/app/views/campaigns/index.html.haml
@@ -1,4 +1,5 @@
 - @campaigns.each do |campaign|    
+    - if campaign.accepted? || current_user.admin?
         %h1
             = link_to campaign.title, campaign_path(campaign)
         - if campaign.image.attached?
@@ -7,6 +8,10 @@
             = truncate(campaign.description, length: 100) { link_to ' (more)', campaign_path(campaign)} 
         %p
             = campaign.location
-        
-        = button_to 'Reject', '#'
-        = button_to 'Accept', campaign_path(campaign, event: :admin_accepts_campaign), method: :put, remote: true
+        - if user_signed_in? && current_user.admin?
+            = button_to 'Reject', '#'
+            = form_with url: admin_accept_path do |form|
+                = form.hidden_field :campaign_id, value: campaign.id
+                = form.submit 'Accept'
+            
+        //= button_to 'Accept', campaign_path(campaign, event: :admin_accepts_campaign), method: :put, remote: true

--- a/app/views/campaigns/show.html.haml
+++ b/app/views/campaigns/show.html.haml
@@ -8,8 +8,8 @@
 
     = image_tag @campaign.image
 
-- if user_signed_in? && current_user.admin?
-    = form_with url: admin_accept_path do |form|
-    = form.hidden_field :campaign_id, value: @campaign.id
-    = form.submit 'Accept'
-    = button_to 'Reject', '#'
+    - if user_signed_in? && current_user.admin?
+        = form_with url: admin_accept_path do |form|
+            = form.hidden_field :campaign_id, value: @campaign.id
+            = form.submit 'Accept'
+        = button_to 'Reject', '#'

--- a/app/views/campaigns/show.html.haml
+++ b/app/views/campaigns/show.html.haml
@@ -7,9 +7,5 @@
         = @campaign.location
 
     = image_tag @campaign.image
-
-    - if user_signed_in? && current_user.admin?
-        = form_with url: admin_accept_path do |form|
-            = form.hidden_field :campaign_id, value: @campaign.id
-            = form.submit 'Accept'
-        = button_to 'Reject', '#'
+    .form-group
+        = link_to 'Accept', campaign_path(@campaign, event: 'accept'), method: :put, class: 'form-submit'

--- a/app/views/campaigns/show.html.haml
+++ b/app/views/campaigns/show.html.haml
@@ -1,8 +1,9 @@
-%h1
-    = @campaign.title
-%p
-    = @campaign.description
-%p
-    = @campaign.location
- 
-= image_tag @campaign.image
+- if @campaign.accepted? || current_user.admin?
+    %h1
+        = @campaign.title
+    %p
+        = @campaign.description
+    %p
+        = @campaign.location
+
+    = image_tag @campaign.image

--- a/app/views/campaigns/show.html.haml
+++ b/app/views/campaigns/show.html.haml
@@ -7,5 +7,7 @@
         = @campaign.location
 
     = image_tag @campaign.image
+    
+- if @campaign.pending? && current_user.admin?
     .form-group
         = link_to 'Accept', campaign_path(@campaign, event: 'accept'), method: :put, class: 'form-submit'

--- a/app/views/campaigns/show.html.haml
+++ b/app/views/campaigns/show.html.haml
@@ -7,3 +7,9 @@
         = @campaign.location
 
     = image_tag @campaign.image
+
+- if user_signed_in? && current_user.admin?
+    = form_with url: admin_accept_path do |form|
+    = form.hidden_field :campaign_id, value: @campaign.id
+    = form.submit 'Accept'
+    = button_to 'Reject', '#'

--- a/app/views/partials/_header.html.haml
+++ b/app/views/partials/_header.html.haml
@@ -7,11 +7,11 @@
                 %td.mui--text-right
                     %ul.mui-list--inline.mui--text-body2
                         %li
-                            %a{href: "#", class: 'mui-btn mui-btn--flat mui-btn--primary'} Campaigns
+                            = link_to 'Campaigns', campaigns_path, remote: true, class: 'mui-btn mui-btn--flat mui-btn--primary'
                         %li
                             %a{href: "#", class: 'mui-btn mui-btn--flat mui-btn--primary'} Artists
                         %li
-                            - if     current_user&.artist?
+                            - if current_user&.artist?
                                 = link_to 'New Campaign', new_campaign_path, remote: true, class: 'mui-btn mui-btn--flat mui-btn--primary'
                         %li
                             - unless current_user

--- a/app/views/partials/_header.html.haml
+++ b/app/views/partials/_header.html.haml
@@ -11,7 +11,7 @@
                         %li
                             %a{href: "#", class: 'mui-btn mui-btn--flat mui-btn--primary'} Artists
                         - if user_signed_in?  
-                            - if current_user.artist?
+                            - if !current_user.fan?
                                 %li
                                     = link_to 'Create Artist Profile', new_performer_path, remote: true, class: 'mui-btn mui-btn--flat mui-btn--primary'
                                 %li

--- a/app/views/partials/_header.html.haml
+++ b/app/views/partials/_header.html.haml
@@ -7,7 +7,7 @@
                 %td.mui--text-right
                     %ul.mui-list--inline.mui--text-body2
                         %li
-                            = link_to 'Campaigns', campaigns_path, remote: true, class: 'mui-btn mui-btn--flat mui-btn--primary'
+                            = link_to 'Campaigns', campaigns_path, class: 'mui-btn mui-btn--flat mui-btn--primary'
                         %li
                             %a{href: "#", class: 'mui-btn mui-btn--flat mui-btn--primary'} Artists
                         - if user_signed_in?  

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     sessions: :sessions
   }
   root controller: :campaigns, action: :index
-  resources :campaigns, only: [:index, :create, :new, :show]
+  resources :campaigns, only: [:index, :create, :new, :show, :update]
+  post :admin_accept, controller: :campaigns, action: :admin_accepts_campaign
   resources :performers, only: [:new, :create, :show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,5 @@ Rails.application.routes.draw do
   }
   root controller: :campaigns, action: :index
   resources :campaigns, only: [:index, :create, :new, :show, :update]
-  post :admin_accept, controller: :campaigns, action: :admin_accepts_campaign
   resources :performers, only: [:new, :create, :show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
     sessions: :sessions
   }
   root controller: :campaigns, action: :index
-  resources :campaigns, only: [:index, :create, :new, :show]
+  resources :campaigns, only: [:index, :create, :new, :show, :update] do
+    put 'admin_accepts_campaign'
+  end
+  
   resources :performers, only: [:new, :create]
 end

--- a/db/migrate/20180907183925_add_state_to_campaign.rb
+++ b/db/migrate/20180907183925_add_state_to_campaign.rb
@@ -1,0 +1,5 @@
+class AddStateToCampaign < ActiveRecord::Migration[5.2]
+  def change
+    add_column :campaigns, :state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_06_142324) do
-
+ActiveRecord::Schema.define(version: 2018_09_07_183925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,7 +43,29 @@ ActiveRecord::Schema.define(version: 2018_09_06_142324) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.string "state"
     t.index ["user_id"], name: "index_campaigns_on_user_id"
+  end
+
+  create_table "performers", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "name"
+    t.string "genre"
+    t.string "city"
+    t.text "description"
+    t.string "facebook"
+    t.string "instagram"
+    t.string "twitter"
+    t.string "website"
+    t.string "spotify"
+    t.string "youtube"
+  end
+
+  create_table "performers_users", id: false, force: :cascade do |t|
+    t.bigint "performer_id", null: false
+    t.bigint "user_id", null: false
+    t.index ["performer_id", "user_id"], name: "index_performers_users_on_performer_id_and_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_06_183954) do
+ActiveRecord::Schema.define(version: 2018_09_07_183925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,3 +18,7 @@ campaigns = Campaign.create([
         location: 'Karlstad'
     }
 ])
+
+
+
+admin = User.create(email: 'admin@venue.se', password: 'my-password', role: 'admin')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,19 +6,24 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
+fan = User.create(email: 'fan@venue.se', password: 'my-password', role: 'fan')
+artist = User.create(email: 'artist@venue.se', password: 'my-password', role: 'artist')
+admin = User.create(email: 'admin@venue.se', password: 'my-password', role: 'admin')
+
 campaigns = Campaign.create([
     {
         title: 'Marius Ipsum',
         description: 'This is a very long description designed to exceed 100 character, so that the truncation sets in and limits the description of the event on the front page. The guest needs to click the title of the campaign to see the full description of the campaign',
-        location: 'Luleå'
+        location: 'Luleå',
+        state: 'pending',
+        user: artist
+
     },
     {
         title: 'Fusce sodales',
         description: 'This is a very long description designed to exceed 100 character, so that the truncation sets in and limits the description of the event on the front page. The guest needs to click the title of the campaign to see the full description of the campaign',
-        location: 'Karlstad'
+        location: 'Karlstad',
+        state: 'accepted',
+        user: artist
     }
 ])
-
-fan = User.create(email: 'fan@venue.se', password: 'my-password', role: 'fan')
-artist = User.create(email: 'artist@venue.se', password: 'my-password', role: 'artist')
-admin = User.create(email: 'admin@venue.se', password: 'my-password', role: 'admin')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,9 +32,9 @@ campaigns = Campaign.create([
         title: 'Someone different',
         description: 'This is a very long description designed to exceed 100 character, so that the truncation sets in and limits the description of the event on the front page. The guest needs to click the title of the campaign to see the full description of the campaign',
         location: 'Stockholm',
-        state: 'pending'
+        state: 'pending',
         user: artist
-    },
+    }
 ])
 
 Campaign.all.each do |campaign|

--- a/features/admin_must_approve_artists_campaigns.feature
+++ b/features/admin_must_approve_artists_campaigns.feature
@@ -14,8 +14,7 @@ Feature: Admin must approve Artists new Campaigns
     
     Scenario: Artist creates a Campaign and Admin approves it
         Given I am logged in as 'admin@venue.se'
-        And I am on the 'Campaigns' page
-        Then I should see 'Veronica Maggio in Stockholm'
+        And I am on the Campaign page for 'Veronica Maggio in Stockholm'
         And the state of the campaign 'Veronica Maggio in Stockholm' should be 'pending'
         When I click on 'Accept'
         Then I wait 1 second

--- a/features/admin_must_approve_artists_campaigns.feature
+++ b/features/admin_must_approve_artists_campaigns.feature
@@ -18,4 +18,5 @@ Feature: Admin must approve Artists new Campaigns
         Then I should see 'Veronica Maggio in Stockholm'
         And the state of the campaign 'Veronica Maggio in Stockholm' should be 'pending'
         When I click on 'Accept'
+        Then I wait 1 second
         Then the state of the campaign 'Veronica Maggio in Stockholm' should be 'accepted'

--- a/features/admin_must_approve_artists_campaigns.feature
+++ b/features/admin_must_approve_artists_campaigns.feature
@@ -1,0 +1,22 @@
+Feature: Admin must approve Artists new Campaigns
+    As a system owner
+    In order to be in control of the applications content
+    I would like to be able to approve all new content created by the Artists
+
+    Background:
+        Given the following user exist
+            | email           | role   |
+            | admin@venue.se  | admin  |
+        And the following campaign exist
+            | title                        | description                                | location  | state   |
+            | Veronica Maggio in Stockholm | Don't miss a fantastic singer in September | Stockholm | pending |
+    
+    Scenario: Artist creates a Campaign and Admin approves it
+        Given I am logged in as 'artist@venue.se'
+        And I am on the 'Campaigns' page
+        Then I should see 'Veronica Maggio in Stockholm'
+        And the state of the campaign 'Veronica Maggio in Stockholm' should be 'pending'
+        And I should see 'Reject'
+        And I should see 'Accept'
+        When I click on 'Accept'
+        Then the state of the campaign 'Veronica Maggio in Stockholm' should be 'accepted'

--- a/features/admin_must_approve_artists_campaigns.feature
+++ b/features/admin_must_approve_artists_campaigns.feature
@@ -1,3 +1,4 @@
+@javascript
 Feature: Admin must approve Artists new Campaigns
     As a system owner
     In order to be in control of the applications content
@@ -14,6 +15,7 @@ Feature: Admin must approve Artists new Campaigns
     Scenario: Artist creates a Campaign and Admin approves it
         Given I am logged in as 'artist@venue.se'
         And I am on the 'Campaigns' page
+        Then stop
         Then I should see 'Veronica Maggio in Stockholm'
         And the state of the campaign 'Veronica Maggio in Stockholm' should be 'pending'
         And I should see 'Reject'

--- a/features/admin_must_approve_artists_campaigns.feature
+++ b/features/admin_must_approve_artists_campaigns.feature
@@ -15,7 +15,6 @@ Feature: Admin must approve Artists new Campaigns
     Scenario: Artist creates a Campaign and Admin approves it
         Given I am logged in as 'artist@venue.se'
         And I am on the 'Campaigns' page
-        Then stop
         Then I should see 'Veronica Maggio in Stockholm'
         And the state of the campaign 'Veronica Maggio in Stockholm' should be 'pending'
         And I should see 'Reject'

--- a/features/admin_must_approve_artists_campaigns.feature
+++ b/features/admin_must_approve_artists_campaigns.feature
@@ -17,7 +17,5 @@ Feature: Admin must approve Artists new Campaigns
         And I am on the 'Campaigns' page
         Then I should see 'Veronica Maggio in Stockholm'
         And the state of the campaign 'Veronica Maggio in Stockholm' should be 'pending'
-        And I should see 'Reject'
-        And I should see 'Accept'
         When I click on 'Accept'
         Then the state of the campaign 'Veronica Maggio in Stockholm' should be 'accepted'

--- a/features/admin_must_approve_artists_campaigns.feature
+++ b/features/admin_must_approve_artists_campaigns.feature
@@ -13,7 +13,7 @@ Feature: Admin must approve Artists new Campaigns
             | Veronica Maggio in Stockholm | Don't miss a fantastic singer in September | Stockholm | pending |
     
     Scenario: Artist creates a Campaign and Admin approves it
-        Given I am logged in as 'artist@venue.se'
+        Given I am logged in as 'admin@venue.se'
         And I am on the 'Campaigns' page
         Then I should see 'Veronica Maggio in Stockholm'
         And the state of the campaign 'Veronica Maggio in Stockholm' should be 'pending'

--- a/features/admin_must_approve_artists_campaigns.feature
+++ b/features/admin_must_approve_artists_campaigns.feature
@@ -15,7 +15,7 @@ Feature: Admin must approve Artists new Campaigns
     Scenario: Artist creates a Campaign and Admin approves it
         Given I am logged in as 'admin@venue.se'
         And I am on the Campaign page for 'Veronica Maggio in Stockholm'
-        And the state of the campaign 'Veronica Maggio in Stockholm' should be 'pending'
+        Then the state of the campaign 'Veronica Maggio in Stockholm' should be 'pending'
         When I click on 'Accept'
         Then I wait 1 second
         Then the state of the campaign 'Veronica Maggio in Stockholm' should be 'accepted'

--- a/features/admin_must_approve_artists_campaigns.feature
+++ b/features/admin_must_approve_artists_campaigns.feature
@@ -6,13 +6,15 @@ Feature: Admin must approve Artists new Campaigns
 
     Background:
         Given the following user exist
-            | email           | role   |
-            | admin@venue.se  | admin  |
+            | email          | role   |
+            | admin@venue.se | admin  |
+            | fan@venue.se   | fan    |    
         And the following campaign exist
-            | title                        | description                                | location  | state   |
-            | Veronica Maggio in Stockholm | Don't miss a fantastic singer in September | Stockholm | pending |
+            | title                        | description                                | location  | state    |
+            | Veronica Maggio in Stockholm | Don't miss a fantastic singer in September | Stockholm | pending  |
+            | Campaign thas is accepted    | This campaigns has been accepted by admin  | Oslo      | accepted |
     
-    Scenario: Artist creates a Campaign and Admin approves it
+    Scenario: Admin accepts Campaign
         Given I am logged in as 'admin@venue.se'
         And I am on the Campaign page for 'Veronica Maggio in Stockholm'
         Then the state of the campaign 'Veronica Maggio in Stockholm' should be 'pending'
@@ -20,3 +22,21 @@ Feature: Admin must approve Artists new Campaigns
         And I wait 1 second
         Then the state of the campaign 'Veronica Maggio in Stockholm' should be 'accepted'
         And I should see 'This campaign is now live!'
+
+    Scenario: Admin sees all Campaigns
+        Given I am logged in as 'admin@venue.se'
+        And I am on the 'Campaigns' page
+        Then I should see 'Veronica Maggio in Stockholm'
+        And I should see 'Campaign thas is accepted'
+        Then I click on 'Veronica Maggio in Stockholm' detail box
+        And I should be redirected to the Campaign page for 'Veronica Maggio in Stockholm'
+        And I should see 'Accept'
+
+    Scenario: Fan only sees Accepted Campaigns and no accept button
+        Given I am logged in as 'fan@venue.se'
+        And I am on the 'Campaigns' page
+        Then I should see 'Campaign thas is accepted'
+        And I should NOT see 'Veronica Maggio in Stockholm'
+        Then I click on 'Campaign thas is accepted' detail box
+        And I should be redirected to the Campaign page for 'Campaign thas is accepted'
+        And I should NOT see 'Accept'

--- a/features/admin_must_approve_artists_campaigns.feature
+++ b/features/admin_must_approve_artists_campaigns.feature
@@ -17,5 +17,6 @@ Feature: Admin must approve Artists new Campaigns
         And I am on the Campaign page for 'Veronica Maggio in Stockholm'
         Then the state of the campaign 'Veronica Maggio in Stockholm' should be 'pending'
         When I click on 'Accept'
-        Then I wait 1 second
+        And I wait 1 second
         Then the state of the campaign 'Veronica Maggio in Stockholm' should be 'accepted'
+        And I should see 'This campaign is now live!'

--- a/features/attaching_image_to_campaign.feature
+++ b/features/attaching_image_to_campaign.feature
@@ -7,7 +7,7 @@ Feature: Attaching image to the campaign
     Background:
         Given the following user exist
         | email          | role   | password   |
-        | user@artist.se | artist | my-pasword |
+        | user@artist.se | admin  | my-pasword |
         And I am logged in as 'user@artist.se'
 
     Scenario: Attaching image to the campaign
@@ -20,7 +20,9 @@ Feature: Attaching image to the campaign
         And I attach an image to the campaign
         And I click on 'Launch Campaign'
         And I wait 1 second
+        And the campaign 'Clare Cunningham' is accepted
         Then I should be redirected to the Campaign page for 'Clare Cunningham'
+        And I wait 1 second
         And I should see the 'dummy.jpg' image
 
     

--- a/features/guest_can_view_full_campaign_page.feature
+++ b/features/guest_can_view_full_campaign_page.feature
@@ -6,8 +6,8 @@ Feature: Guests can view the full Campaign page
 
     Background:
         Given the following campaign exist
-        | title                        | description                                | location  |
-        | Veronica Maggio in Stockholm | Don't miss a fantastic singer in September | Stockholm |
+        | title                        | description                                | location  | state    |
+        | Veronica Maggio in Stockholm | Don't miss a fantastic singer in September | Stockholm | accepted |
 
     Scenario: Guest can view the full description of Campaign
         Given I am on the 'landing' page

--- a/features/guests_can_view_list_of_campaigns_landing_page.feature
+++ b/features/guests_can_view_list_of_campaigns_landing_page.feature
@@ -6,8 +6,8 @@ Feature: Guests can view the list of Campaigns on the landing page
 
     Background:
         Given the following campaign exist
-        | title                        | description                                | location  |
-        | Veronica Maggio in Stockholm | Don't miss a fantastic singer in September | Stockholm |
+        | title                        | description                                | location  | state    |
+        | Veronica Maggio in Stockholm | Don't miss a fantastic singer in September | Stockholm | accepted |
 
     Scenario: 
         When I am on the 'landing' page

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -66,3 +66,8 @@ Then("the state of the campaign {string} should be {string}") do |campaign_title
     campaign = Campaign.find_by(title: campaign_title)
     expect(campaign.state).to eq campaign_state
 end
+
+Then("the campaign {string} is accepted") do |campaign_title|
+    campaign = Campaign.find_by(title: campaign_title)
+    campaign.admin_accepts_campaign!
+end

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -24,10 +24,6 @@ Then("I should be redirected to the Campaign page for {string}") do |title|
     expect(current_path).to eq campaign_path(campaign)
 end
 
-Then("I should be redirected to the landing page") do |string|
-    expect(current_path).to eq root_path
-end
-
 Then("It should be a user in the database with the email {string}") do |expected_email|
     user = User.find_by(email: expected_email)
     expect(user.email).to eq expected_email
@@ -36,8 +32,13 @@ end
 Then("I should see the {string} image") do |file_name|
     expect(page).to have_css "img[src*='#{file_name}']"
 end
-  
+
 Then("I should be on {string} campaign page") do |campaign_title|
-  campaign = Campaign.find_by(title: campaign_title)
-  expect(current_path).to eq campaign_path(campaign)
+    campaign = Campaign.find_by(title: campaign_title)
+    expect(current_path).to eq campaign_path(campaign)
+end
+
+Then("the state of the campaign {string} should be {string}") do |campaign_title, campaign_state|
+    campaign = Campaign.find_by(title: campaign_title)
+    expect(campaign.state).to eq campaign_state
 end

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -69,5 +69,5 @@ end
 
 Then("the campaign {string} is accepted") do |campaign_title|
     campaign = Campaign.find_by(title: campaign_title)
-    campaign.admin_accepts_campaign!
+    campaign.accept
 end

--- a/features/step_definitions/background_steps.rb
+++ b/features/step_definitions/background_steps.rb
@@ -1,10 +1,10 @@
-Given("the following campaign exist(s)") do |table|
+Given("the following campaign(s) exist(s)") do |table|
     table.hashes.each do |campaign_hash|
         create(:campaign, campaign_hash)
     end
 end
 
-Given("the following user(s) exist") do |table|
+Given("the following user(s) exist(s)") do |table|
     table.hashes.each do |user_hash|
         create(:user, user_hash)
     end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -2,7 +2,6 @@ And ("I click( on) {string}") do |link|
     click_on link
 end
 
-
 And ("I click( on) {string} detail box") do |campaign_title|
     campaign = Campaign.find_by(title: campaign_title)
     find("##{ActionView::RecordIdentifier.dom_id(campaign)}").click

--- a/features/step_definitions/paths_steps.rb
+++ b/features/step_definitions/paths_steps.rb
@@ -17,3 +17,8 @@ end
 Given("I try to access {string} page") do |page_name|
   visit page_path(page_name)
 end
+
+Given("I am on the Campaign page for {string}") do |campaign_title|
+  campaign_page = Campaign.find_by(title: campaign_title)
+  campaign_path(campaign_page)
+end

--- a/features/step_definitions/paths_steps.rb
+++ b/features/step_definitions/paths_steps.rb
@@ -20,5 +20,5 @@ end
 
 Given("I am on the Campaign page for {string}") do |campaign_title|
   campaign_page = Campaign.find_by(title: campaign_title)
-  campaign_path(campaign_page)
+  visit campaign_path(campaign_page)
 end

--- a/features/step_definitions/paths_steps.rb
+++ b/features/step_definitions/paths_steps.rb
@@ -5,6 +5,8 @@ end
 def page_path(path)
   if path == 'Create Campaign'
     new_campaign_path
+  elsif path == 'Campaigns'
+    campaigns_path
   else
     root_path
   end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -23,11 +23,11 @@ Cucumber::Rails::Database.javascript_strategy = :truncation
 
 Chromedriver.set_version '2.36'
 
- Capybara.register_driver :selenium do |app|
+Capybara.register_driver :selenium do |app|
   options = Selenium::WebDriver::Chrome::Options.new(
       args: %w(disable-popup-blocking disable-infobars)
   )
-   Capybara::Selenium::Driver.new(
+  Capybara::Selenium::Driver.new(
       app,
       browser: :chrome,
       options: options

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -17,7 +17,7 @@ Before do
   OmniAuth.config.test_mode = true
   OmniAuth.config.mock_auth[:facebook] = OmniAuth::AuthHash.new(OmniAuthFixtures.facebook_mock)
   OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(OmniAuthFixtures.google_oauth2_response)
-  3.times {FactoryBot.create(:campaign)}
+  3.times {FactoryBot.create(:campaign, state: :accepted)}
 end
 
 Cucumber::Rails::Database.javascript_strategy = :truncation

--- a/spec/factories/campaigns.rb
+++ b/spec/factories/campaigns.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
     description { "MyText" }
     location { "MyString" }
     user
-     after(:build) do |campaign|
-       campaign.image.attach(io: File.open(Rails.root.join('spec', 'fixtures', 'dummy.jpg')), filename: "image.jpg", content_type: 'image/jpg')
-   end
+    after(:build) do |campaign|
+      campaign.image.attach(io: File.open(Rails.root.join('spec', 'fixtures', 'dummy.jpg')), filename: "image.jpg", content_type: 'image/jpg')
+    end
   end
 end

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe Campaign, type: :model do
     subject { create(:campaign) }
 
     it { is_expected.to have_states :pending, :accepted }
-    it { is_expected.to handle_events :admin_accepts_campaign, when: :pending }
+    it { is_expected.to handle_events :accept, when: :pending }
 
     it ':admin_accepts_campaign transitions from :pending to :accepted' do
-      subject.admin_accepts_campaign
+      subject.accept
       expect(subject.accepted?).to eq true
     end
   end

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -1,10 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe Campaign, type: :model do
+  
   describe 'DB table' do
+    it { is_expected.to have_db_column :title }
+    it { is_expected.to have_db_column :description }
+    it { is_expected.to have_db_column :location }
+    it { is_expected.to have_db_column :state }
+  end
+  
+  describe 'Validations' do
     it { is_expected.to validate_presence_of :title }
     it { is_expected.to validate_presence_of :description }
     it { is_expected.to validate_presence_of :location }
+    it { is_expected.to validate_presence_of :state }
+
   end
 
   describe 'Factory' do
@@ -21,6 +31,18 @@ RSpec.describe Campaign, type: :model do
     it 'is valid  ' do
       subject.image.attach(io: File.open(fixture_path + '/dummy.jpg'), filename: 'dummy.jpg', content_type: 'image/jpg')
       expect(subject.image).to be_attached
+    end
+  end
+
+  describe 'Check for states, events and transistions' do
+    subject { create(:campaign) }
+
+    it { is_expected.to have_states :pending, :accepted }
+    it { is_expected.to handle_events :admin_accepts_campaign, when: :pending }
+
+    it ':admin_accepts_campaign transitions from :pending to :accepted' do
+      subject.admin_accepts_campaign
+      expect(subject.accepted?).to eq true
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe User, type: :model do
   describe 'User roles' do
     let(:user_fan) { create :user, role: :fan }
     let(:user_artist) { create :user, role: :artist }
+    let(:user_admin) { create :user, role: :admin }
+
 
     it 'fan responds true if role is fan' do
       expect(user_fan.fan?).to eq true
@@ -37,6 +39,14 @@ RSpec.describe User, type: :model do
 
     it 'artist responds false if role is not artist' do
       expect(user_artist.fan?).to eq false
+    end
+
+    it 'admin responds true if role is admin' do
+      expect(user_admin.admin?).to eq true
+    end
+
+    it 'admin responds false if role is not artist' do
+      expect(user_admin.fan?).to eq false
     end
   end
 

--- a/spec/policies/campaign_policy_spec.rb
+++ b/spec/policies/campaign_policy_spec.rb
@@ -14,4 +14,9 @@ RSpec.describe CampaignPolicy do
         let(:user) { create(:user, role: 'artist') }
         it { is_expected.to permit_actions [:index, :show, :create, :new] }
     end
+
+    context 'user is an admin' do
+        let(:user) { create(:user, role: 'admin') }
+        it { is_expected.to permit_actions [:index, :show, :create, :new] }
+    end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,6 +16,7 @@ RSpec.configure do |config|
     config.infer_spec_type_from_file_location!
     config.filter_rails_from_backtrace!
     config.include FactoryBot::Syntax::Methods
+    config.include StateMachinesRspec::Matchers
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
## PT-link:
https://www.pivotaltracker.com/story/show/160217010
Chore: https://www.pivotaltracker.com/story/show/160380938

## User story:
```
As a system owner
In order to be in control of the applications content
I would like to be able to approve all new content created by the Artists
```

## Tasks
- Add `Admin` as a `enum` role
- Add approval-`button` only visible for registered user with `Admin`enum-role
- Add "status" of `Campaigns` eg. `pending` as default
- Add gem 'state machine'
- Add gem 'state_machines-rspec'

Former task: - Check that new `Campaigns` are not displayed before being approved be `Admin` moved to chore: https://www.pivotaltracker.com/story/show/160380938

## New gems
gem `state_machines-activerecord`
gem `state_machines-rspec`

## New Migrations
AddStateToCampaign
`add_column :campaigns, :state, :string`