### PR TITLE
Make rezisable Modals

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -43,22 +43,37 @@ const initiateSlider = (selector) => {
 }
 
 const showPartialAsModal = (html, dimensions) => {
-    let modalEl = document.createElement('div');
-    modalEl.style.width = dimensions.width;
-    modalEl.style.height = dimensions.height;
-    modalEl.style.margin = '60px auto';
-    modalEl.style.padding = '20px 20px';
-    modalEl.style.backgroundColor = '#293239';
-    modalEl.innerHTML = html;
+    let modal = document.createElement('div');
+    modal.style.width = dimensions.width;
+    modal.style.height = dimensions.height;
+    modal.style.margin = '60px auto';
+    modal.style.padding = '20px 20px';
+    modal.style.backgroundColor = '#293239';
+    modal.innerHTML = html;
 
-    mui.overlay('on', modalEl, {
+    mui.overlay('on', modal, {
         static: true
     });
+
+    return modal;
 }
 
-const cancelModal = (event) => {
+const cancelModal = event => {
     event.preventDefault();
     mui.overlay('off');
+}
+
+const resizableModal = (modal, height) => {
+    let originalModelHeight = modal.offsetHeight;
+    document.addEventListener('iziToast-opening', (data) => {
+        setTimeout(null, 500);
+        modal.style.height = `${originalModelHeight + height}px`;
+        modal.style.transition = '0.5s';
+    });
+
+    document.addEventListener('iziToast-closed', () => {
+        modal.style.height = `${originalModelHeight}px`;   
+    });
 }
 
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,13 +3,14 @@ $mui-label-font-color: rgba(white, 0.7);
 $mui-input-font-color: rgba(white, 0.7);
 $mui-input-placeholder-color: rgba(white, 0.7);
 $mui-form-legend-font-color: rgba(white, 0.7);
-$mui-btn-primary-bg-color : $mui-primary-color;
+$mui-btn-primary-bg-color: $mui-primary-color;
 $mui-btn-flat-bg-color-hover: darken($mui-primary-color, 5%);
 $mui-overlay-bg-color: rgba($mui-primary-color, 0.70);
 @import url('https://fonts.googleapis.com/css?family=Lato:300,400,700,900');
 @import 'mui';
 @import 'mui_extensions';
 @import 'izitoast/dist/css/iziToast.min.css';
+@import "font-awesome-sprockets";
 @import "font-awesome";
 html {
     margin: 0;
@@ -124,41 +125,41 @@ img.faux {
 
 .carousel {
     .carousel-control {
-      cursor: pointer;
-      background: transparent none;
-      width: 100px;
-      -moz-transition: all 0.3s ease 0s;
-      -webkit-transition: all 0.3s ease 0s;
-      transition: all 0.3s ease 0s;
-      z-index: 999;
-      &:hover {
+        cursor: pointer;
         background: transparent none;
         width: 100px;
         -moz-transition: all 0.3s ease 0s;
         -webkit-transition: all 0.3s ease 0s;
         transition: all 0.3s ease 0s;
-      }
-      svg {
-        height: 40px;
-        width: 40px;
-        -moz-transform: translate(-50%, -50%);
-        -webkit-transform: translate(-50%, -50%);
-        transform: translate(-50%, -50%);
-      }
-      &:nth-of-type(1) {
-        position: absolute;
-        left: 0;
-        top: 50%;
-      }
-      
-      &:nth-of-type(2) {
-        position: absolute;
-        right: 0;
-        top: 50%;
-        transform: translate(+50%);
-      }
+        z-index: 999;
+        &:hover {
+            background: transparent none;
+            width: 100px;
+            -moz-transition: all 0.3s ease 0s;
+            -webkit-transition: all 0.3s ease 0s;
+            transition: all 0.3s ease 0s;
+        }
+        svg {
+            height: 40px;
+            width: 40px;
+            -moz-transform: translate(-50%, -50%);
+            -webkit-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+        }
+        &:nth-of-type(1) {
+            position: absolute;
+            left: 0;
+            top: 50%;
+        }
+        &:nth-of-type(2) {
+            position: absolute;
+            right: 0;
+            top: 50%;
+            transform: translate(+50%);
+        }
     }
-  }
+}
+
 /* 1.1 Forms */
 
 .form-submit {
@@ -233,7 +234,6 @@ img.faux {
             }
         }
     }
-
     .form-checkbox {
         display: table;
         font-size: 12px;
@@ -284,37 +284,10 @@ img.faux {
 }
 
 .social-login-buttons {
-    padding: 50px 0;
-    a {
-        border-radius: 5px;
-        display: table;
-        font-size: 15px;
-        height: 47px;
-        line-height: 47px;
-        margin: 0 auto;
-        padding-left: 47px;
-        width: 208px;
-        +a {
-            margin-top: 20px;
-        }
-    }
     .facebook {
         background-color: #4267B2;
-        &::before {
-            background: transparent image-url('icon-facebook.jpg') center center no-repeat;
-            background-size: contain;
-            border-radius: 2px;
-            content: '';
-            display: block;
-            height: 26px;
-            left: 13px;
-            width: 26px;
-            position: absolute;
-            top: 50%;
-            -moz-transform: translateY(-50%);
-            -webkit-transform: translateY(-50%);
-            transform: translateY(-50%);
-        }
+        background: transparent image-url('icon-facebook.jpg') no-repeat;
+        background-size: contain;
     }
     .google {
         background-color: #FFF;

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,11 +3,10 @@ class RegistrationsController < Devise::RegistrationsController
 
     def create 
         build_resource(sign_up_params)
-        resource.save
-        if resource.persisted?
+        if resource.save
             flash[:notice] = 'Welcome! You have signed up successfully.'
             sign_up(resource_name, resource)
-            render js: "Turbolinks.visit(Turbolinks.absoluteURL, {action: 'reload'})"
+            redirect_to root_path
         else
             errors = resource.errors.full_messages
             render json: {message: errors}, status: 422

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,9 +10,9 @@ class SessionsController < Devise::SessionsController
     if self.resource
       sign_in(resource_name, resource)
       flash[:notice] = 'Signed in successfully.'
-      render js: "Turbolinks.visit(Turbolinks.absoluteURL, {action: 'reload'})"
+      redirect_to root_path
     else
-      render json: {message: 'Could not log you in'}, status: 422
+      render json: {message: 'Could not log you in'}, status: :unauthorized
     end
   end
 

--- a/app/views/devise/registrations/_form.html.haml
+++ b/app/views/devise/registrations/_form.html.haml
@@ -18,6 +18,6 @@
           = button_tag 'Cancel', class: 'form-submit', onclick: 'cancelModal(event);' 
       %div{style: 'margin-top: 20px;'} 
         %h3 Prefer to use your social media account? 
-        = link_to icon('fab', 'facebook-f', "Log in with Facebook", user_facebook_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
-        = link_to icon('fab', 'google-plus-g', "Log in with Google", user_google_oauth2_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
+        = link_to icon('fab', 'facebook-f', "Log in with Facebook"), user_facebook_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
+        = link_to icon('fab', 'google-plus-g', "Log in with Google"), user_google_oauth2_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
 

--- a/app/views/devise/registrations/_form.html.haml
+++ b/app/views/devise/registrations/_form.html.haml
@@ -2,8 +2,8 @@
   .mui-row
     .mui-col-md-8.mui-col-md-offset-2
       %h2 Sign up with Email address
-      #display_error_message
-      = form_for(resource, as: resource_name, url: registration_path(resource_name), remote: true, html: {class: 'mui-form'}) do |f|
+      = tag :div, id: dom_id(resource, :errors)
+      = form_with(model: resource, as: resource_name, url: registration_path(resource_name), remote: true, class: 'mui-form') do |f|
         .mui-textfield.mui-textfield--float-label
           = f.email_field :email, autofocus: true
           = f.label :email, 'Email address'

--- a/app/views/devise/registrations/_form.html.haml
+++ b/app/views/devise/registrations/_form.html.haml
@@ -1,6 +1,6 @@
 .mui-container-fluid
   .mui-row
-    .mui-col-md-8.mui-col-md-offset-2
+    .mui-col-lg-8.mui-col-lg-offset-2.mui-col-md-12
       %h2 Sign up with Email address
       = tag :div, id: dom_id(resource, :errors)
       = form_with(model: resource, as: resource_name, url: registration_path(resource_name), remote: true, class: 'mui-form') do |f|
@@ -13,13 +13,11 @@
         .mui-textfield.mui-textfield--float-label
           = f.password_field :password_confirmation
           = f.label :password_confirmation, 'Re-Type Password'
-        %form-group
+        %div
           = f.submit "Sign up for Venue", class: 'form-submit'
           = button_tag 'Cancel', class: 'form-submit', onclick: 'cancelModal(event);' 
-        .social-login-buttons  
-          .facebook
-            = link_to "Sign up with Facebook", user_facebook_omniauth_authorize_path
-            %br/
-          .google
-            = link_to "Sign up with Google", user_google_oauth2_omniauth_authorize_path
+      %div{style: 'margin-top: 20px;'} 
+        %h3 Prefer to use your social media account? 
+        = link_to icon('fab', 'facebook-f', t('header.log_in_with_facebook')), user_facebook_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
+        = link_to icon('fab', 'google-plus-g', t('header.log_in_with_google')), user_google_oauth2_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
 

--- a/app/views/devise/registrations/_form.html.haml
+++ b/app/views/devise/registrations/_form.html.haml
@@ -18,6 +18,6 @@
           = button_tag 'Cancel', class: 'form-submit', onclick: 'cancelModal(event);' 
       %div{style: 'margin-top: 20px;'} 
         %h3 Prefer to use your social media account? 
-        = link_to icon('fab', 'facebook-f', "Log in with Facebook"), user_facebook_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
-        = link_to icon('fab', 'google-plus-g', "Log in with Google"), user_google_oauth2_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
+        = link_to icon('fab', 'facebook-f', "Sign up with Facebook"), user_facebook_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
+        = link_to icon('fab', 'google-plus-g', "Sign up with Google"), user_google_oauth2_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
 

--- a/app/views/devise/registrations/_form.html.haml
+++ b/app/views/devise/registrations/_form.html.haml
@@ -18,6 +18,6 @@
           = button_tag 'Cancel', class: 'form-submit', onclick: 'cancelModal(event);' 
       %div{style: 'margin-top: 20px;'} 
         %h3 Prefer to use your social media account? 
-        = link_to icon('fab', 'facebook-f', t('header.log_in_with_facebook')), user_facebook_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
-        = link_to icon('fab', 'google-plus-g', t('header.log_in_with_google')), user_google_oauth2_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
+        = link_to icon('fab', 'facebook-f', "Log in with Facebook", user_facebook_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
+        = link_to icon('fab', 'google-plus-g', "Log in with Google", user_google_oauth2_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
 

--- a/app/views/devise/registrations/new.js.erb
+++ b/app/views/devise/registrations/new.js.erb
@@ -1,7 +1,9 @@
-var html = "<%= escape_javascript(render 'devise/registrations/form')%>"
-showPartialAsModal(html, {width: '60%', height: '50%'});
+var html, modal, form
+html = "<%= escape_javascript(render 'form')%>"
+modal = showPartialAsModal(html, {width: '60%', height: '50%'});
+form = document.querySelector('.mui-form')
+resizableModal(modal, 70)
 
-var form = document.querySelector('.mui-form')
 form.addEventListener('ajax:error', (event) => {
-    showToast('Error', event.detail[0].message, {target: '#display_error_message'});
+    showToast('Error', event.detail[0].message, {target: '#<%= dom_id(resource, :errors) %>'});
 })

--- a/app/views/devise/registrations/new.js.erb
+++ b/app/views/devise/registrations/new.js.erb
@@ -1,6 +1,6 @@
 var html, modal, form
 html = "<%= escape_javascript(render 'form')%>"
-modal = showPartialAsModal(html, {width: '60%', height: '50%'});
+modal = showPartialAsModal(html, {width: '60vw', height: '65vh'});
 form = document.querySelector('.mui-form')
 resizableModal(modal, 70)
 

--- a/app/views/devise/sessions/_form.html.haml
+++ b/app/views/devise/sessions/_form.html.haml
@@ -18,5 +18,5 @@
                     = button_tag 'Cancel', class: 'form-submit', onclick: 'cancelModal(event);' 
             %div{style: 'margin-top: 20px;'} 
             %h3 Log in using your social media account 
-            = link_to icon('fab', 'facebook-f', t('header.log_in_with_facebook')), user_facebook_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
-            = link_to icon('fab', 'google-plus-g', t('header.log_in_with_google')), user_google_oauth2_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
+            = link_to icon('fab', 'facebook-f', "Sign up with Facebook", user_facebook_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
+            = link_to icon('fab', 'google-plus-g', "Sign up with Google", user_google_oauth2_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"

--- a/app/views/devise/sessions/_form.html.haml
+++ b/app/views/devise/sessions/_form.html.haml
@@ -1,6 +1,6 @@
 .mui-container-fluid
     .mui-row
-        .mui-col-md-8.mui-col-md-offset-2
+        .mui-col-lg-8.mui-col-lg-offset-2.mui-col-md-12
             %h2 Log in with Email address
             = tag :div, id: dom_id(resource, :errors)
             = form_with(model: resource, as: resource_name, url: session_path(resource_name), remote: true, class: 'mui-form') do |f|
@@ -16,3 +16,7 @@
                 %div
                     = f.submit 'Login', class: 'form-submit'
                     = button_tag 'Cancel', class: 'form-submit', onclick: 'cancelModal(event);' 
+            %div{style: 'margin-top: 20px;'} 
+            %h3 Log in using your social media account 
+            = link_to icon('fab', 'facebook-f', t('header.log_in_with_facebook')), user_facebook_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
+            = link_to icon('fab', 'google-plus-g', t('header.log_in_with_google')), user_google_oauth2_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"

--- a/app/views/devise/sessions/_form.html.haml
+++ b/app/views/devise/sessions/_form.html.haml
@@ -18,5 +18,5 @@
                     = button_tag 'Cancel', class: 'form-submit', onclick: 'cancelModal(event);' 
             %div{style: 'margin-top: 20px;'} 
             %h3 Log in using your social media account 
-            = link_to icon('fab', 'facebook-f', "Sign up with Facebook", user_facebook_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
-            = link_to icon('fab', 'google-plus-g', "Sign up with Google", user_google_oauth2_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
+            = link_to icon('fab', 'facebook-f', "Sign up with Facebook"), user_facebook_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"
+            = link_to icon('fab', 'google-plus-g', "Sign up with Google"), user_google_oauth2_omniauth_authorize_path, class: 'form-submit', onclick: "mui.overlay('on')"

--- a/app/views/devise/sessions/_form.html.haml
+++ b/app/views/devise/sessions/_form.html.haml
@@ -2,8 +2,8 @@
     .mui-row
         .mui-col-md-8.mui-col-md-offset-2
             %h2 Log in with Email address
-            #display_error_message
-            = form_for(resource, as: resource_name, url: session_path(resource_name), remote: true, html: {class: 'mui-form'}) do |f|
+            = tag :div, id: dom_id(resource, :errors)
+            = form_with(model: resource, as: resource_name, url: session_path(resource_name), remote: true, class: 'mui-form') do |f|
                 .mui-textfield.mui-textfield--float-label
                     = f.email_field :email, autofocus: true
                     = f.label :email, 'Email address'
@@ -13,6 +13,6 @@
                 - if devise_mapping.rememberable?
                     = f.check_box :remember_me
                     = f.label :remember_me
-                .form-group
+                %div
                     = f.submit 'Login', class: 'form-submit'
                     = button_tag 'Cancel', class: 'form-submit', onclick: 'cancelModal(event);' 

--- a/app/views/devise/sessions/new.js.erb
+++ b/app/views/devise/sessions/new.js.erb
@@ -1,6 +1,6 @@
 var html, modal, form
 html = "<%= escape_javascript(render 'form')%>"
-modal = showPartialAsModal(html, {width: '60%', height: '50%'});
+modal = showPartialAsModal(html, {width: '60vw', height: '60vh'});
 form = document.querySelector('.mui-form')
 resizableModal(modal, 70)
 

--- a/app/views/devise/sessions/new.js.erb
+++ b/app/views/devise/sessions/new.js.erb
@@ -1,7 +1,12 @@
-var html = "<%= escape_javascript(render 'devise/sessions/form')%>"
-showPartialAsModal(html, {width: '60%', height: '50%'});
+var html, modal, form
+html = "<%= escape_javascript(render 'form')%>"
+modal = showPartialAsModal(html, {width: '60%', height: '50%'});
+form = document.querySelector('.mui-form')
+resizableModal(modal, 70)
 
-var form = document.querySelector('.mui-form')
 form.addEventListener('ajax:error', (event) => {
-    showToast('Error', event.detail[0].message, {target: '#display_error_message'});
+    showToast('Error', event.detail[0].message, {target: '#<%= dom_id(resource, :errors) %>'});
 })
+
+
+


### PR DESCRIPTION
## PT-link:
https://www.pivotaltracker.com/story/show/160227152

## Tasks
- Simplifies `controller methods` (removes unnecessary `js render`)
- Adds a function to make a `MUI CSS modal` resizable by adding `EventListeners`

## New gems
No new gems

## New Migrations
No new Migrations

![vanue_resizable_modal](https://user-images.githubusercontent.com/5248170/45252488-728a6800-b357-11e8-9791-31e44e9a313c.gif)


![screen shot 2018-09-08 at 11 55 06](https://user-images.githubusercontent.com/5248170/45252891-24c52e00-b35e-11e8-9813-c8dd57ba6d4b.png)
![screen shot 2018-09-08 at 11 54 13](https://user-images.githubusercontent.com/5248170/45252892-24c52e00-b35e-11e8-8848-e73824268719.png)



