### PR TITLE
(WIP)Users can share Profiles and Campaigns on social media

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,11 +16,9 @@ gem 'devise'
 gem 'omniauth-facebook'
 gem 'pundit'
 gem 'omniauth-google-oauth2', '~> 0.5.3'
-
-## CSS Frameworks and support
-## MUI is 'almost' like Bootstrap but without jQuery. Allegedly ;-) 
 gem 'mui-sass', '~> 0.9.35'
 gem 'font-awesome-sass', '~> 5.0', '>= 5.0.13'
+gem 'social-share-button'
 
 group :development, :test do
   gem 'chromedriver-helper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,13 @@ GEM
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
     coderay (1.1.2)
+    coffee-rails (4.2.2)
+      coffee-script (>= 2.2.0)
+      railties (>= 4.0.0)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     coveralls (0.8.22)
       json (>= 1.8, < 3)
@@ -291,6 +298,8 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    social-share-button (1.1.0)
+      coffee-rails
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -359,6 +368,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   shoulda-matchers
+  social-share-button
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,7 @@
 //= require mui
 //= require siema/dist/siema.min.js
 //= require izitoast/dist/js/iziToast.min.js
+//= require social-share-button
 //= require_tree .
 
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@ $mui-overlay-bg-color: rgba($mui-primary-color, 0.70);
 @import 'izitoast/dist/css/iziToast.min.css';
 @import "font-awesome-sprockets";
 @import "font-awesome";
+@import "social-share-button";
 html {
     margin: 0;
     padding: 0;

--- a/app/views/performers/show.html.haml
+++ b/app/views/performers/show.html.haml
@@ -13,3 +13,6 @@
 = link_to 'Youtube', @performer.youtube
 = link_to 'Website', @performer.website
 = link_to 'Spotify', @performer.spotify
+
+= social_share_button_tag('Share to Facebook', :url => performer_path(@performer), desc: @performer.name)
+= social_share_button_tag('Share to Twitter', @performer.name)

--- a/config/initializers/social_share_button.rb
+++ b/config/initializers/social_share_button.rb
@@ -1,0 +1,3 @@
+SocialShareButton.configure do |config|
+  config.allow_sites = %w(twitter facebook)
+end


### PR DESCRIPTION
## PT link
https://www.pivotaltracker.com/story/show/160369990

## User story
```
As a system owner
In order to gain more traffic to my site
I would like my users to be able to share content on social media
```

## Tasks
- Add gem 'social-share-button'
- Configure for twitter and Facebook
- Add media share buttons to campaign and artist profiles (performer)

## New Gems:
`gem 'social-share-button'`
