### PR TITLE
[WIP] Admin can edit and destroy campaigns

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -44,6 +44,11 @@ class CampaignsController < ApplicationController
    end
   end
 
+  def destroy
+    @campaign = Campaign.find(params[:id])
+    @campaign.destroy
+    redirect_to campaigns_path, notice: 'Campaign deleted'
+  end
 
 private
 

--- a/app/policies/campaign_policy.rb
+++ b/app/policies/campaign_policy.rb
@@ -14,5 +14,13 @@ class CampaignPolicy < ApplicationPolicy
 
     def show?
         true
-    end    
+    end
+
+    def update?
+        user.admin?
+    end
+
+    def destroy?
+        user.admin?
+    end
 end

--- a/app/views/campaigns/show.html.haml
+++ b/app/views/campaigns/show.html.haml
@@ -17,3 +17,6 @@
 - if @campaign.pending? && current_user.admin?
     .form-group
         = link_to 'Accept', campaign_path(@campaign, event: 'accept'), method: :put, class: 'form-submit'
+- if user_signed_in? && current_user.admin?
+    .form-group
+        = link_to 'Delete Campaign',

--- a/app/views/campaigns/show.html.haml
+++ b/app/views/campaigns/show.html.haml
@@ -19,4 +19,4 @@
         = link_to 'Accept', campaign_path(@campaign, event: 'accept'), method: :put, class: 'form-submit'
 - if user_signed_in? && current_user.admin?
     .form-group
-        = link_to 'Delete Campaign',
+        = link_to 'Delete Campaign', campaign_path(@campaign), method: :delete, data: { confirm: 'Are you sure?' }, class: 'form-submit'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     sessions: :sessions
   }
   root controller: :campaigns, action: :index
-  resources :campaigns, only: [:index, :create, :new, :show, :update]
+  resources :campaigns, only: [:index, :create, :new, :show, :update, :destroy]
   resources :performers, only: [:new, :create, :show]
   resources :tickets, only: [:create]
 end

--- a/features/admin_can_edit_and_delete_campaigns.feature
+++ b/features/admin_can_edit_and_delete_campaigns.feature
@@ -1,22 +1,25 @@
+@javascript
 Feature: Admin can edit and delete campaigns
     As an Admin
     In order to be in control of the content of the Campaigns
     I would like to be able to edit and delete Campaigns
 
     Background:
-        Given the following user exist
-            | email          | role   |
-            | admin@venue.se | admin  |
-        And the following campaign exist
-            | title                        | state     |
-            | Veronica Maggio in Stockholm | accepted  |
+        Given the following campaign exist
+        | title                         |
+        | Veronica Maggio in Stockholm  |
+        And the following user exist
+        | email          | role  |
+        | admin@venue.se | admin |
+        And I am logged in as 'admin@venue.se'
 
     Scenario: Admin can delete campaign
-        Given I am logged in as 'admin@venue.se'
-        And I am on the 'landing' page
-        And I click on 'Veronica Maggio in Stockholm' detail box
-        Then I should be redirected to the Campaign page for 'Veronica Maggio in Stockholm'
+        Given I am on the Campaign page for 'Veronica Maggio in Stockholm'
         And I click on 'Delete Campaign'
-        Then there should be a Campaign titled 'Veronica Maggio in Stockholm' in the Database
+        And I click on 'OK' in the confirmation popup
+        Then I wait 1 second
+        Then there should NOT be a Campaign titled 'Veronica Maggio in Stockholm' in the Database
+        And I should see 'Campaign deleted'
+        And I should be redirected to the 'Campaigns' page
 
     Scenario: Admin can edit campaign

--- a/features/admin_can_edit_and_delete_campaigns.feature
+++ b/features/admin_can_edit_and_delete_campaigns.feature
@@ -1,0 +1,4 @@
+Feature: Admin can edit and delete campaigns
+    As an Admin
+    In order to be in control of the content of the Campaigns
+    I would like to be able to edit and delete Campaigns

--- a/features/admin_can_edit_and_delete_campaigns.feature
+++ b/features/admin_can_edit_and_delete_campaigns.feature
@@ -2,3 +2,21 @@ Feature: Admin can edit and delete campaigns
     As an Admin
     In order to be in control of the content of the Campaigns
     I would like to be able to edit and delete Campaigns
+
+    Background:
+        Given the following user exist
+            | email          | role   |
+            | admin@venue.se | admin  |
+        And the following campaign exist
+            | title                        | state     |
+            | Veronica Maggio in Stockholm | accepted  |
+
+    Scenario: Admin can delete campaign
+        Given I am logged in as 'admin@venue.se'
+        And I am on the 'landing' page
+        And I click on 'Veronica Maggio in Stockholm' detail box
+        Then I should be redirected to the Campaign page for 'Veronica Maggio in Stockholm'
+        And I click on 'Delete Campaign'
+        Then there should be a Campaign titled 'Veronica Maggio in Stockholm' in the Database
+
+    Scenario: Admin can edit campaign

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -15,6 +15,11 @@ Then("there should be a Campaign titled {string} in the Database") do |expected_
     expect(campaign).not_to eq nil
 end
 
+Then("there should NOT be a Campaign titled {string} in the Database") do |campaign_title|
+    campaign = Campaign.find_by(title: campaign_title)
+    expect(campaign).to eq nil
+end
+
 Then("I should be redirected to the {string} page") do |page_name|
     expect(current_path).to eq page_path(page_name)    
 end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -32,3 +32,7 @@ And('I fill in ticket fields') do
     And I fill in 'Ticket name' with 'Sure thing'
   )
 end
+
+And ("I click on {string} in the confirmation popup") do |string|
+  page.driver.browser.switch_to.alert.accept
+end

--- a/spec/policies/campaign_policy_spec.rb
+++ b/spec/policies/campaign_policy_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe CampaignPolicy do
 
     context 'user is an admin' do
         let(:user) { create(:user, role: 'admin') }
-        it { is_expected.to permit_actions [:index, :show, :create, :new] }
+        it { is_expected.to permit_actions [:index, :show, :create, :new, :update, :destroy] }
     end
 end


### PR DESCRIPTION
## PT link
https://www.pivotaltracker.com/story/show/160234888

## User Story
As an Admin
In order to be in control of the content of the Campaigns
I would like to be able to edit and delete Campaigns

## Tasks
- Admin has edit and delete rights to Campaigns
- Add button only visible to Admins on Campaign pages
