### PR TITLE
Admin can edit Campaigns

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -46,9 +46,9 @@ class CampaignsController < ApplicationController
       campaign.accept
       redirect_to campaign, notice: 'This campaign is now live!'
     else    
-    @campaign = Campaign.find(params[:id])
-    @campaign.update_attributes(campaign_params)
-    redirect_to campaign_path(@campaign), notice: 'Campaign has been successfully updated'
+      @campaign = Campaign.find(params[:id])
+      @campaign.update_attributes(campaign_params)
+      redirect_to campaign_path(@campaign), notice: 'Campaign has been successfully updated'
     end
   end
 

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -36,14 +36,21 @@ class CampaignsController < ApplicationController
     @campaign = Campaign.find(params[:id])
   end
 
-  def update
-   campaign = Campaign.find(params[:id])
-   if params[:event] == 'accept'
-     campaign.accept
-     redirect_to campaign, notice: 'This campaign is now live!'
-   end
+  def edit
+    @campaign = Campaign.find(params[:id])
   end
 
+  def update
+    if params[:event] == 'accept'
+      campaign = Campaign.find(params[:id])
+      campaign.accept
+      redirect_to campaign, notice: 'This campaign is now live!'
+    else    
+    @campaign = Campaign.find(params[:id])
+    @campaign.update_attributes(campaign_params)
+    redirect_to campaign_path(@campaign), notice: 'Campaign has been successfully updated'
+    end
+  end
 
 private
 

--- a/app/policies/campaign_policy.rb
+++ b/app/policies/campaign_policy.rb
@@ -14,5 +14,9 @@ class CampaignPolicy < ApplicationPolicy
 
     def show?
         true
-    end    
+    end
+    
+    def update?
+        user.admin?
+    end
 end

--- a/app/views/campaigns/edit.html.haml
+++ b/app/views/campaigns/edit.html.haml
@@ -1,0 +1,29 @@
+.mui-container-fluid
+  .mui-row
+    .mui-col-md-8.mui-col-md-offset-2
+      %h2 Edit Campaign
+      #display_error_message
+      = form_with model: @campaign, method: :patch, class: 'mui-form' do |form|
+        .mui-textfield.mui-textfield--float-label
+          = form.text_field :title
+          = form.label :title
+        .mui-textfield.mui-textfield--float-label
+          = form.text_area :description, rows: 10
+          = form.label :description
+        .mui-textfield.mui-textfield--float-label
+          = form.text_field :location
+          = form.label :location
+        %div
+          = form.fields_for :tickets, Ticket.new do |ticket_form|
+            .mui-textfield.mui-textfield--float-label
+              = ticket_form.number_field :price 
+              = ticket_form.label :price, 'Fixed ticket price'
+            .mui-textfield.mui-textfield--float-label 
+              = ticket_form.text_field :name  
+              = ticket_form.label :name, 'Ticket name'        
+        .form-group   
+          = form.label :image
+          = form.file_field :image 
+        .form-group
+          = form.submit 'Update Campaign', class: 'form-submit'
+          = button_tag 'Cancel', class: 'form-submit', onclick: 'cancelModal(event);' 

--- a/app/views/campaigns/show.html.haml
+++ b/app/views/campaigns/show.html.haml
@@ -17,3 +17,6 @@
 - if @campaign.pending? && current_user.admin?
     .form-group
         = link_to 'Accept', campaign_path(@campaign, event: 'accept'), method: :put, class: 'form-submit'
+- if user_signed_in? && current_user.admin?
+    .form-group
+        = link_to 'Edit', edit_campaign_path(@campaign), class: 'form-submit'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     sessions: :sessions
   }
   root controller: :campaigns, action: :index
-  resources :campaigns, only: [:index, :create, :new, :show, :update]
+  resources :campaigns, only: [:index, :create, :new, :show, :update, :edit]
   resources :performers, only: [:new, :create, :show]
   resources :tickets, only: [:create]
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,18 @@
 fan = User.create(email: 'fan@venue.se', password: 'my-password', role: 'fan')
 artist = User.create(email: 'artist@venue.se', password: 'my-password', role: 'artist')
-
-fan = User.create(email: 'fan@venue.se', password: 'my-password', role: 'fan')
-artist = User.create(email: 'artist@venue.se', password: 'my-password', role: 'artist')
 admin = User.create(email: 'admin@venue.se', password: 'my-password', role: 'admin')
+
+artist.performers.create(
+    name: 'Clare Cunningham',
+    genre: 'Rock',
+    city: 'Stockholm',
+    description: 'Dubbed as having a vocal register similar to Adele (GAFFA) and for having a "Powerfull and killer voice" from Lzzy Hale (Halestorm) and Phil Campell (Motörhead) it is no wonder Clare Cunningham is making waves across the world with her music. Storytelling with unwavering honesty is what Cunningham is best at, and this little country rock/pop chick has proven she is a multi versatile recording and live artist, singing across many genres.',
+    facebook: 'https://www.facebook.com',
+    instagram: 'https://www.instagram.com',
+    twitter: 'https://www.twitter.com',
+    youtube: 'https://www.youtube.com',
+    spotify: 'https://www.spotify.com'   
+)
 
 campaigns = Campaign.create([
     {
@@ -40,17 +49,3 @@ campaigns = Campaign.create([
 Campaign.all.each do |campaign|
     campaign.image.attach(io: File.open(Rails.root.join('spec', 'fixtures', 'dummy.jpg')), filename: "image.jpg", content_type: 'image/jpg')
 end
-
-artist.performers.create(
-    name: 'Clare Cunningham',
-    genre: 'Rock',
-    city: 'Stockholm',
-    description: 'Dubbed as having a vocal register similar to Adele (GAFFA) and for having a "Powerfull and killer voice" from Lzzy Hale (Halestorm) and Phil Campell (Motörhead) it is no wonder Clare Cunningham is making waves across the world with her music. Storytelling with unwavering honesty is what Cunningham is best at, and this little country rock/pop chick has proven she is a multi versatile recording and live artist, singing across many genres.',
-    facebook: 'https://www.facebook.com',
-    instagram: 'https://www.instagram.com',
-    twitter: 'https://www.twitter.com',
-    youtube: 'https://www.youtube.com',
-
-    spotify: 'https://www.spotify.com'   
-    )
-

--- a/features/admin_can_edit_campaigns.feature
+++ b/features/admin_can_edit_campaigns.feature
@@ -15,11 +15,13 @@ Feature: Admin can edit Campaigns
 
     Scenario: Admin can edit Campaign
         When I am on the Campaign page for 'Veronica Maggio in Stockholm'
-        And I click on 'Edit Campaign'
+        And I click on 'Edit'
         Then I should be redirected to the Edit page for 'Veronica Maggio in Stockholm'
         And I fill in 'Title' with 'Veronica Maggio in Oslo'
         And I fill in 'Description' with 'I have moved to Oslo'
         And I fill in 'Location' with 'Oslo'
         And I click 'Update Campaign'
+        And I wait 1 second
+        And I should see 'Campaign has been successfully updated'
         Then there should be a Campaign titled 'Veronica Maggio in Oslo' in the Database
         And I should be redirected to the Campaign page for 'Veronica Maggio in Oslo'

--- a/features/admin_can_edit_campaigns.feature
+++ b/features/admin_can_edit_campaigns.feature
@@ -1,0 +1,25 @@
+@javascript
+Feature: Admin can edit Campaigns
+    As an Admin
+    In order to be in control of the content of the Campaigns and maintain a high quality
+    I would like to be able to Edit existing Campaigns
+
+    Background:
+        Given the following campaign exist
+        | title                        |
+        | Veronica Maggio in Stockholm |
+        And the following user exist
+        | email         | role  |
+        | admin@venue.se| admin |
+        And I am logged in as 'admin@venue.se'
+
+    Scenario: Admin can edit Campaign
+        When I am on the Campaign page for 'Veronica Maggio in Stockholm'
+        And I click on 'Edit Campaign'
+        Then I should be redirected to the Edit page for 'Veronica Maggio in Stockholm'
+        And I fill in 'Title' with 'Veronica Maggio in Oslo'
+        And I fill in 'Description' with 'I have moved to Oslo'
+        And I fill in 'Location' with 'Oslo'
+        And I click 'Update Campaign'
+        Then there should be a Campaign titled 'Veronica Maggio in Oslo' in the Database
+        And I should be redirected to the Campaign page for 'Veronica Maggio in Oslo'

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -82,3 +82,8 @@ Then("I should see {string} in ticket info") do |expected_content|
         expect(page).to have_content expected_content
     end
 end 
+
+Then("I should be redirected to the Edit page for {string}") do |campaign_title|
+    campaign = Campaign.find_by(title: campaign_title)
+    expect(current_path).to eq edit_campaign_path(campaign)
+end

--- a/spec/policies/campaign_policy_spec.rb
+++ b/spec/policies/campaign_policy_spec.rb
@@ -7,16 +7,17 @@ RSpec.describe CampaignPolicy do
     context 'user is a fan' do
         let(:user) { create(:user, role: 'fan') }
         it { is_expected.to permit_actions [:index, :show] }
-        it { is_expected.to forbid_actions [:create, :new] }
+        it { is_expected.to forbid_actions [:create, :new, :update] }
     end
     
     context 'user is an artist' do
         let(:user) { create(:user, role: 'artist') }
         it { is_expected.to permit_actions [:index, :show, :create, :new] }
+        it { is_expected.to forbid_actions [:update] }
     end
 
     context 'user is an admin' do
         let(:user) { create(:user, role: 'admin') }
-        it { is_expected.to permit_actions [:index, :show, :create, :new] }
+        it { is_expected.to permit_actions [:index, :show, :create, :new, :update] }
     end
 end


### PR DESCRIPTION
## PT link
https://www.pivotaltracker.com/story/show/160410606

## User Story
```
As an Admin
In order to be in control of the content of the Campaigns and maintain a high quality
I would like to be able to Edit existing Campaigns
```

## Tasks
- Add Edit functionality to `campaigns#update`
- Restrict edit function to Admin
- Add edit link only visible to Admin

## No new gems or migrations
![admin_edits_campaign](https://user-images.githubusercontent.com/39304568/45355006-7cae9f80-b5bf-11e8-9ab8-bf3fbef19215.gif)
