### PR TITLE
Chore: Add styling to Campaign page

### DIFF
--- a/app/views/campaigns/show.html.haml
+++ b/app/views/campaigns/show.html.haml
@@ -1,19 +1,79 @@
-- if @campaign.accepted? || current_user.admin?
-    %h1
-        = @campaign.title
-    %p
-        = @campaign.description
-    %p
-        = @campaign.location
-
-    = image_tag @campaign.image
-
-= social_share_button_tag(@campaign.title, allow_sites: %w(twitter facebook))
-#tickets 
-    - @campaign.tickets.each do |ticket|
-        = [ticket.name, ticket.price].join(': ')
-
-            
-- if @campaign.pending? && current_user.admin?
+#content
+  .mui-container
+    #artist-campaign.mui-row.campaign-details
+      .mui-col-md-12.mui-col-lg-6.has-campaign-picture
+        .campaign-picture
+          = image_tag @campaign.image
+      .mui-col-md-12.mui-col-lg-6.has-campaign-details
+        %h2
+          = @campaign.title
+        .mui-row.has-location-genre-visit-profile
+          .mui-col-xs-6
+            .location-genre
+              .location
+                = @campaign.location
+              .genre Rock
+          .mui-col-xs-6
+            %a.visit-profile{href: "artist-profile.html"} Visit Profile
+        .campaign-description
+          %p
+            = @campaign.description
+        .mui-row
+          .mui-col-xs-6
+            .campaign-date
+              .icon-label
+                %svg#Capa_1{style: "enable-background:new 0 0 512 512;", version: "1.1", viewbox: "0 0 512 512", x: "0px", "xml:space" => "preserve", xmlns: "http://www.w3.org/2000/svg", "xmlns:xlink" => "http://www.w3.org/1999/xlink", y: "0px"}
+                  %g
+                    %g
+                      %g
+                        %path{d: "M279,364c0,22.056,17.944,40,40,40h47c22.056,0,40-17.944,40-40v-47c0-22.056-17.944-40-40-40h-47\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t\tc-22.056,0-40,17.944-40,40V364z M319,317h47l0.025,46.999c0,0-0.007,0.001-0.025,0.001h-47V317z"}
+                        %circle{cx: "386", cy: "210", r: "20"}
+                        %circle{cx: "299", cy: "210", r: "20"}
+                        %path{d: "M492,352c11.046,0,20-8.954,20-20V120c0-44.112-35.888-80-80-80h-26V20c0-11.046-8.954-20-20-20\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t\tc-11.046,0-20,8.954-20,20v20h-91V20c0-11.046-8.954-20-20-20s-20,8.954-20,20v20h-90V20c0-11.046-8.954-20-20-20\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t\ts-20,8.954-20,20v20H80C35.888,40,0,75.888,0,120v312c0,44.112,35.888,80,80,80h352c44.112,0,80-35.888,80-80\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t\tc0-11.046-8.954-20-20-20c-11.046,0-20,8.954-20,20c0,22.056-17.944,40-40,40H80c-22.056,0-40-17.944-40-40V120\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t\tc0-22.056,17.944-40,40-40h25v20c0,11.046,8.954,20,20,20s20-8.954,20-20V80h90v20c0,11.046,8.954,20,20,20\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t\tc11.046,0,20-8.954,20-20V80h91v20c0,11.046,8.954,20,20,20c11.046,0,20-8.954,20-20V80h26c22.056,0,40,17.944,40,40v212\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t\tC472,343.046,480.954,352,492,352z"}
+                        %circle{cx: "125", cy: "384", r: "20"}
+                        %circle{cx: "125", cy: "210", r: "20"}
+                        %circle{cx: "125", cy: "297", r: "20"}
+                        %circle{cx: "212", cy: "297", r: "20"}
+                        %circle{cx: "212", cy: "210", r: "20"}
+                        %circle{cx: "212", cy: "384", r: "20"}
+                .label Date
+              .date 16 May 2018
+          .mui-col-xs-6
+            .campaign-date
+              .icon-label
+                %svg#Capa_1{style: "enable-background:new 0 0 512 512;", version: "1.1", viewbox: "0 0 512 512", x: "0px", "xml:space" => "preserve", xmlns: "http://www.w3.org/2000/svg", "xmlns:xlink" => "http://www.w3.org/1999/xlink", y: "0px"}
+                  %g
+                    %g
+                      %path{d: "M466.96,380.91c-2.033-10.857-12.483-18.009-23.341-15.974c-10.856,2.035-18.009,12.485-15.975,23.341\r\n\t\t\t\t\t\t\t\t\t\t\t\t\tc1.51,8.055-2.031,13.795-4.275,16.5c-2.239,2.697-7.215,7.223-15.38,7.223H104.397c-8.165,0-13.141-4.525-15.38-7.223\r\n\t\t\t\t\t\t\t\t\t\t\t\t\tc-2.244-2.705-5.785-8.445-4.275-16.5c5.673-30.272,17.056-50.183,28.064-69.439C126.176,295.455,140,271.274,140,234v-30\r\n\t\t\t\t\t\t\t\t\t\t\t\t\tc0-63.067,51.263-115.072,114.302-115.987h3.781C320.908,88.925,372,140.93,372,204v30c0,31.723,10.377,53.552,20.104,71.523\r\n\t\t\t\t\t\t\t\t\t\t\t\t\tc3.62,6.688,10.5,10.484,17.606,10.484c3.215,0,6.477-0.777,9.502-2.415c9.715-5.257,13.327-17.395,8.069-27.108\r\n\t\t\t\t\t\t\t\t\t\t\t\t\tC417.604,268.602,412,254.281,412,234v-30c0-41.161-15.943-80.037-44.894-109.466C342.296,69.312,310.439,53.574,276,49.23V20\r\n\t\t\t\t\t\t\t\t\t\t\t\t\tc0-11.046-8.954-20-20-20c-11.046,0-20,8.954-20,20v29.289C159.542,59.209,100,125.181,100,204v30\r\n\t\t\t\t\t\t\t\t\t\t\t\t\tc0,26.647-9.673,43.566-21.919,64.986c-12.064,21.104-25.739,45.023-32.655,81.924c-3.301,17.616,1.369,35.626,12.813,49.414\r\n\t\t\t\t\t\t\t\t\t\t\t\t\tC69.673,444.1,86.497,452,104.397,452h91.989c0,33.084,26.916,60,60,60s60-26.916,60-60h91.603c17.9,0,34.725-7.9,46.158-21.676\r\n\t\t\t\t\t\t\t\t\t\t\t\t\tC465.591,416.536,470.261,398.526,466.96,380.91z M256.387,472c-11.028,0-20-8.972-20-20h40\r\n\t\t\t\t\t\t\t\t\t\t\t\t\tC276.387,463.028,267.415,472,256.387,472z"}
+                  %g
+                    %g
+                      %path{d: "M108.363,45.098c-8.23-7.368-20.874-6.668-28.241,1.562C41.352,89.97,20,145.85,20,204.006c0,11.046,8.954,20,20,20\r\n\t\t\t\t\t\t\t\t\t\t\t\t\ts20-8.954,20-20c0-48.298,17.73-94.703,49.925-130.667C117.292,65.109,116.593,52.465,108.363,45.098z"}
+                  %g
+                    %g
+                      %path{d: "M431.878,46.66c-7.367-8.229-20.012-8.929-28.241-1.562s-8.929,20.011-1.562,28.241\r\n\t\t\t\t\t\t\t\t\t\t\t\t\tC434.27,109.304,452,155.708,452,204.006c0,11.046,8.954,20,20,20c11.046,0,20-8.954,20-20\r\n\t\t\t\t\t\t\t\t\t\t\t\t\tC492,145.85,470.648,89.97,431.878,46.66z"}
+                .label Days to go
+              .date 30 Days left
+        .mui-row.tickets-by-price
+          - @campaign.tickets.each do |ticket|  
+            %input#artcamp_tick_01{checked: "checked", name: "artcamp_tick", type: "radio", value: "150 SEK"}/
+            %label.mui-col-xs-4.ticket{for: "artcamp_tick_01"}
+              = [ticket.name, ticket.price].join(': ')
+        .mui-row
+          .mui-col-md-12
+            %a.campaign-book-a-ticket{"data-target" => "#purchase-ticket", "data-toggle" => "modal", href: "#"}
+              Book A Spot
+              %svg{style: "enable-background:new 0 0 24 24;", version: "1.1", viewbox: "0 0 24 24", x: "0px", "xml:space" => "preserve", xmlns: "http://www.w3.org/2000/svg", "xmlns:xlink" => "http://www.w3.org/1999/xlink", y: "0px"}
+                %polygon{fill: "rgb(240,215,93)", points: "24,12 13.5,1.5 11.1,3.8 17.9,10.6 0,10.6 0,13.9 17.4,13.9 11.1,20.2 13.5,22.5 21.7,14.3 21.7,14.3"}
+        .mui-row
+          .mui-col-md-12
+            .share-campaign
+              %label Share:
+              %ul
+                %li
+                  = social_share_button_tag(@campaign.title, allow_sites: %w(twitter facebook))
+  - if @campaign.pending? && current_user.admin?
     .form-group
-        = link_to 'Accept', campaign_path(@campaign, event: 'accept'), method: :put, class: 'form-submit'
+      = link_to 'Accept', campaign_path(@campaign, event: 'accept'), method: :put, class: 'form-submit'
+-#   #tickets 
+-#     - @campaign.tickets.each do |ticket|
+-#       = [ticket.name, ticket.price].join(': ')

--- a/features/guest_can_view_full_campaign_page.feature
+++ b/features/guest_can_view_full_campaign_page.feature
@@ -13,6 +13,6 @@ Feature: Guests can view the full Campaign page
         Given I am on the 'landing' page
         And I click on 'Veronica Maggio in Stockholm' detail box
         Then I should be redirected to the Campaign page for 'Veronica Maggio in Stockholm'
-        And I should see 'Veronica Maggio in Stockholm'
+        And I should see 'VERONICA MAGGIO IN STOCKHOLM'
         And I should see "Don't miss a fantastic singer in September"
         And I should see 'Stockholm'

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -78,7 +78,7 @@ Then("there should be a Ticket named {string} in the Database") do |expected_nam
 end
 
 Then("I should see {string} in ticket info") do |expected_content| 
-    within("#tickets") do 
+    within(".mui-row.tickets-by-price") do 
         expect(page).to have_content expected_content
     end
 end 


### PR DESCRIPTION
## PT link
https://www.pivotaltracker.com/story/show/160417194

## User story
```
As a system owner
In order to have my campaigns look pretty
I would like to apply some styling
```

## Tasks

## View
- Add styling to campaign page
- Replace hardcoded stuff with ours from DB
<img width="960" alt="campaign page" src="https://user-images.githubusercontent.com/39304568/45360597-56ddc680-b5d0-11e8-9f5c-62f9c3a65f5d.png">
