### PR TITLE
[WIP] Admin can archive Artist-profiles

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -54,7 +54,7 @@ private
     campaign = Campaign.find(params[:id])
     if params[:event] == 'accept'
       campaign.accept
-      redirect_to campaign, notice: 'This campaign is now live!'
+      redirect_to campaigns_path, notice: 'This campaign is now live!'
     elsif
       params[:event] == 'archive'
       campaign.archive

--- a/app/controllers/performers_controller.rb
+++ b/app/controllers/performers_controller.rb
@@ -33,7 +33,8 @@ class PerformersController < ApplicationController
             :twitter,
             :youtube,
             :website,
-            :spotify
+            :spotify,
+            :state
             )
     end
 end

--- a/app/controllers/performers_controller.rb
+++ b/app/controllers/performers_controller.rb
@@ -2,6 +2,10 @@ class PerformersController < ApplicationController
     respond_to :js
     before_action :authenticate_user!, only: [:create]
 
+    def index
+        @performers = Performer.all
+    end
+    
     def new
         @performer = Performer.new
     end
@@ -18,6 +22,14 @@ class PerformersController < ApplicationController
 
     def show
         @performer = Performer.find(params[:id])
+    end
+
+    def update
+        performer = Performer.find(params[:id])
+        if params[:event] == 'archive'
+            performer.archive
+            redirect_to performers_path, notice: 'Performer has been archived'
+        end
     end
 
     private

--- a/app/models/performer.rb
+++ b/app/models/performer.rb
@@ -1,5 +1,12 @@
 class Performer < ApplicationRecord
-    validates_presence_of :name, :genre, :city, :description
+    validates_presence_of :name, :genre, :city, :description, :state
     has_and_belongs_to_many :users
     has_many :campaigns, through: :users
+
+    state_machine :state, initial: :active do 
+        event :archive do
+            transition active: :archived
+        end
+    end
+
 end

--- a/app/views/partials/_header.html.haml
+++ b/app/views/partials/_header.html.haml
@@ -7,7 +7,7 @@
                     %li
                         = link_to 'Campaigns', campaigns_path
                     %li
-                        %a{href: "#"} Artists
+                        = link_to 'Artists', performers_path
                     - if user_signed_in? && !current_user.fan?
                         %li
                             = link_to 'Create Artist Profile', new_performer_path, remote: true

--- a/app/views/performers/index.html.haml
+++ b/app/views/performers/index.html.haml
@@ -1,0 +1,3 @@
+- @performers.each do |performer|
+    %h2
+        = link_to performer.name, performer_path(performer)

--- a/app/views/performers/show.html.haml
+++ b/app/views/performers/show.html.haml
@@ -18,6 +18,9 @@
           %h3
             %a.active{href: "#"} Overview
             %a{href: "#"} Shows
+            - if @performer.active? && current_user.admin?
+              .form-group
+                = link_to 'Archive', performer_path(@performer, event: 'archive'), method: :put, data: { confirm: 'Are you sure?' }, class: 'form-submit'
       .mui-row.details-spotify
         .mui-col-md-12.mui-col-lg-8
           %h2= @performer.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,6 @@ Rails.application.routes.draw do
   }
   root controller: :campaigns, action: :index
   resources :campaigns, only: [:index, :create, :new, :show, :update]
-  resources :performers, only: [:new, :create, :show]
+  resources :performers, only: [:new, :create, :show, :index, :update]
   resources :tickets, only: [:create]
 end

--- a/db/migrate/20180911142118_add_state_to_performer.rb
+++ b/db/migrate/20180911142118_add_state_to_performer.rb
@@ -1,0 +1,5 @@
+class AddStateToPerformer < ActiveRecord::Migration[5.2]
+  def change
+    add_column :performers, :state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_07_211316) do
+ActiveRecord::Schema.define(version: 2018_09_11_142118) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 2018_09_07_211316) do
     t.string "website"
     t.string "spotify"
     t.string "youtube"
+    t.string "state"
   end
 
   create_table "performers_users", id: false, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,20 @@
 fan = User.create(email: 'fan@venue.se', password: 'my-password', role: 'fan')
 artist = User.create(email: 'artist@venue.se', password: 'my-password', role: 'artist')
-
-fan = User.create(email: 'fan@venue.se', password: 'my-password', role: 'fan')
-artist = User.create(email: 'artist@venue.se', password: 'my-password', role: 'artist')
 admin = User.create(email: 'admin@venue.se', password: 'my-password', role: 'admin')
+
+artist.performers.create(
+    name: 'Clare Cunningham',
+    genre: 'Rock',
+    city: 'Stockholm',
+    description: 'Dubbed as having a vocal register similar to Adele (GAFFA) and for having a "Powerfull and killer voice" from Lzzy Hale (Halestorm) and Phil Campell (Motörhead) it is no wonder Clare Cunningham is making waves across the world with her music. Storytelling with unwavering honesty is what Cunningham is best at, and this little country rock/pop chick has proven she is a multi versatile recording and live artist, singing across many genres.',
+    facebook: 'https://www.facebook.com',
+    instagram: 'https://www.instagram.com',
+    twitter: 'https://www.twitter.com',
+    youtube: 'https://www.youtube.com',
+    website: 'https://www.google.com',
+    spotify: 'https://www.spotify.com',
+    state: 'active'  
+)
 
 campaigns = Campaign.create([
     {
@@ -40,17 +51,5 @@ campaigns = Campaign.create([
 Campaign.all.each do |campaign|
     campaign.image.attach(io: File.open(Rails.root.join('spec', 'fixtures', 'dummy.jpg')), filename: "image.jpg", content_type: 'image/jpg')
 end
-
-artist.performers.create(
-    name: 'Clare Cunningham',
-    genre: 'Rock',
-    city: 'Stockholm',
-    description: 'Dubbed as having a vocal register similar to Adele (GAFFA) and for having a "Powerfull and killer voice" from Lzzy Hale (Halestorm) and Phil Campell (Motörhead) it is no wonder Clare Cunningham is making waves across the world with her music. Storytelling with unwavering honesty is what Cunningham is best at, and this little country rock/pop chick has proven she is a multi versatile recording and live artist, singing across many genres.',
-    facebook: 'https://www.facebook.com',
-    instagram: 'https://www.instagram.com',
-    twitter: 'https://www.twitter.com',
-    youtube: 'https://www.youtube.com',
-
-    spotify: 'https://www.spotify.com'   
-    )
-
+campaign = Campaign.with_state(:accepted).first
+campaign.tickets.create(name: 'Sure thing', price: 200)

--- a/features/admin_archive_artist_profile_performer.feature
+++ b/features/admin_archive_artist_profile_performer.feature
@@ -1,0 +1,21 @@
+@javascript
+Feature: Admin can archove Artist-profile
+    As an Admin
+    In order to be in control of the content of the Artist profiles
+    I would like to be able to edit and delete Artist profile
+
+    Background:
+        Given that the following Performer exist
+        | name       | state  |
+        | Kanye West | active |
+        And that the following user exist
+        | email          | role  |
+        | admin@venue.se | admin |
+        And I am logged in as 'admin@venue.se'
+
+    Scenario: Admin archives a no longer relevant Performer
+        When I am on the Performer page for 'Kanye West'
+        And I click on 'Archive'
+        Then the state of 'Kanye West' should be 'archived'
+        And I should see 'Performer has been archived'
+        And I should be redirected to the 'Performers' page

--- a/features/admin_archive_artist_profile_performer.feature
+++ b/features/admin_archive_artist_profile_performer.feature
@@ -5,10 +5,10 @@ Feature: Admin can archove Artist-profile
     I would like to be able to edit and delete Artist profile
 
     Background:
-        Given that the following Performer exist
+        Given the following Performer exist
         | name       | state  |
         | Kanye West | active |
-        And that the following user exist
+        And the following user exist
         | email          | role  |
         | admin@venue.se | admin |
         And I am logged in as 'admin@venue.se'
@@ -16,6 +16,6 @@ Feature: Admin can archove Artist-profile
     Scenario: Admin archives a no longer relevant Performer
         When I am on the Performer page for 'Kanye West'
         And I click on 'Archive'
-        Then the state of 'Kanye West' should be 'archived'
+        Then the state of the performer 'Kanye West' should be 'archived'
         And I should see 'Performer has been archived'
         And I should be redirected to the 'Performers' page

--- a/features/admin_archive_artist_profile_performer.feature
+++ b/features/admin_archive_artist_profile_performer.feature
@@ -16,6 +16,8 @@ Feature: Admin can archove Artist-profile
     Scenario: Admin archives a no longer relevant Performer
         When I am on the Performer page for 'Kanye West'
         And I click on 'Archive'
+        And I click on 'OK' in the confirmation popup
+        Then I wait 1 second
         Then the state of the performer 'Kanye West' should be 'archived'
         And I should see 'Performer has been archived'
         And I should be redirected to the 'Performers' page

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -67,6 +67,11 @@ Then("the state of the campaign {string} should be {string}") do |campaign_title
     expect(campaign.state).to eq campaign_state
 end
 
+Then("the state of the performer {string} should be {string}") do |performer_name, performer_state|
+    performer = Performer.find_by(name: performer_name)
+    expect(performer.state).to eq performer_state
+end
+
 Then("the campaign {string} is accepted") do |campaign_title|
     campaign = Campaign.find_by(title: campaign_title)
     campaign.accept
@@ -81,4 +86,4 @@ Then("I should see {string} in ticket info") do |expected_content|
     within(".mui-row.tickets-by-price") do 
         expect(page).to have_content expected_content
     end
-end 
+end

--- a/features/step_definitions/background_steps.rb
+++ b/features/step_definitions/background_steps.rb
@@ -23,7 +23,7 @@ Given("the google authentication is not granted") do
     OmniAuth.config.mock_auth[:google_oauth2] = :invalid_credentials
 end
 
-Given("the following Performer(s) exist(s)" do |table|
+Given("the following Performer(s) exist(s)") do |table|
     table.hashes.each do |performer_hash|
         create(:performer, performer_hash)
     end

--- a/features/step_definitions/background_steps.rb
+++ b/features/step_definitions/background_steps.rb
@@ -22,3 +22,9 @@ end
 Given("the google authentication is not granted") do
     OmniAuth.config.mock_auth[:google_oauth2] = :invalid_credentials
 end
+
+Given("the following Performer(s) exist(s)" do |table|
+    table.hashes.each do |performer_hash|
+        create(:performer, performer_hash)
+    end
+end

--- a/features/step_definitions/paths_steps.rb
+++ b/features/step_definitions/paths_steps.rb
@@ -9,6 +9,8 @@ def page_path(path)
     campaigns_path
   elsif path == 'Create Artist Profile'
     new_performer_path
+  elsif path == 'Performers'
+    performers_path
   else
     root_path
   end
@@ -25,4 +27,5 @@ end
 
 When("I am on the Performer page for {string}") do |performer_name|
   performer = Performer.find_by(name: performer_name)
+  visit performer_path(performer)
 end

--- a/features/step_definitions/paths_steps.rb
+++ b/features/step_definitions/paths_steps.rb
@@ -22,3 +22,7 @@ Given("I am on the Campaign page for {string}") do |campaign_title|
   campaign_page = Campaign.find_by(title: campaign_title)
   visit campaign_path(campaign_page)
 end
+
+When("I am on the Performer page for {string}") do |performer_name|
+  performer = Performer.find_by(name: performer_name)
+end

--- a/spec/factories/performers.rb
+++ b/spec/factories/performers.rb
@@ -10,5 +10,6 @@ FactoryBot.define do
     youtube { "MyString" }
     website { "MyString" }
     spotify { "MyString" }
+    state { "active" }
   end
 end

--- a/spec/models/performer_spec.rb
+++ b/spec/models/performer_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Performer, type: :model do
     it { is_expected.to have_db_column :youtube }
     it { is_expected.to have_db_column :website }
     it { is_expected.to have_db_column :spotify }
+    it { is_expected.to have_db_column :state }
+
   end
 
   describe 'Validates' do
@@ -19,6 +21,8 @@ RSpec.describe Performer, type: :model do
     it { is_expected.to validate_presence_of :genre }
     it { is_expected.to validate_presence_of :city }
     it { is_expected.to validate_presence_of :description }
+    it { is_expected.to validate_presence_of :state }
+
   end
   
   describe 'Associations' do
@@ -29,6 +33,18 @@ RSpec.describe Performer, type: :model do
   describe "Factory" do
     it "for :user is valid" do
       expect(create(:performer)).to be_valid
+    end
+  end
+
+  describe 'Check for states, events and transistions' do
+    subject { create(:performer) }
+
+    it { is_expected.to have_states :active, :archived }
+    it { is_expected.to handle_events :archive, when: :active }
+
+    it ':archive transitions from :active to :archive' do
+      subject.archive
+      expect(subject.archived?).to eq true
     end
   end
 end


### PR DESCRIPTION
## PT link
https://www.pivotaltracker.com/story/show/160217025

## User story
```
As an Admin
In order to be in control of the content of the Artist profiles
I would like to be able to edit and delete Artist profile
```

## Tasks
- Add state to Performer: Active and archived
- Admin can archive them
- Add Archive-`button` to Artists profile only visible for registered user with `Admin` enum-role 
- Only display active Performers to users unless admin

## New migrations
`AddStateToPerformer`
