### PR TITLE
Artist can only edit own profile

### DIFF
--- a/app/controllers/performers_controller.rb
+++ b/app/controllers/performers_controller.rb
@@ -40,7 +40,7 @@ class PerformersController < ApplicationController
             redirect_to performers_path, notice: 'Performer has been archived'
         else
             @performer.update_attributes(performer_params)
-            redirect_to performer_path(@performer), notice: 'Profile has been successfullu updated'
+            redirect_to performer_path(@performer), notice: 'Profile has been successfully updated'
             authorize @performer
         end
     end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -5,4 +5,13 @@ class ApplicationPolicy
     @user = user
     @record = record
   end
+
+
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
 end

--- a/app/policies/campaign_policy.rb
+++ b/app/policies/campaign_policy.rb
@@ -8,14 +8,6 @@ class CampaignPolicy < ApplicationPolicy
         new?
     end
 
-    def index?
-        true
-    end
-
-    def show?
-        true
-    end
-    
     def edit?
         user.admin?
     end

--- a/app/policies/performer_policy.rb
+++ b/app/policies/performer_policy.rb
@@ -7,17 +7,9 @@ class PerformerPolicy < ApplicationPolicy
     def create?
         new?
     end
-
-    def index?
-        true
-    end
-
-    def show?
-        true
-    end
     
     def edit?
-        user.admin?
+        user.artist? && record.users.ids.include?(user.id) || user.admin?
     end
 
     def update?

--- a/app/views/performers/show.html.haml
+++ b/app/views/performers/show.html.haml
@@ -24,7 +24,7 @@
               %ul.admin-links
                 %ul
                   %li
-                    - if user_signed_in? && current_user.admin?
+                    - if user_signed_in? && current_user.admin? || policy(@performer).edit?
                       = link_to 'Edit', edit_performer_path(@performer), remote: true, class: 'form-submit'
                     - if @performer.active? && current_user.admin?
                       = link_to 'Archive', performer_path(@performer, event: 'archive'), method: :put, data: { confirm: 'Are you sure?' }, class: 'form-submit'

--- a/app/views/performers/show.html.haml
+++ b/app/views/performers/show.html.haml
@@ -24,7 +24,7 @@
               %ul.admin-links
                 %ul
                   %li
-                    - if user_signed_in? && current_user.admin? || policy(@performer).edit?
+                    - if user_signed_in? && policy(@performer).edit?
                       = link_to 'Edit', edit_performer_path(@performer), remote: true, class: 'form-submit'
                     - if @performer.active? && current_user.admin?
                       = link_to 'Archive', performer_path(@performer, event: 'archive'), method: :put, data: { confirm: 'Are you sure?' }, class: 'form-submit'

--- a/features/admin_can_edit_performer_page.feature
+++ b/features/admin_can_edit_performer_page.feature
@@ -30,7 +30,7 @@ Feature: Admin can edit Artist-profiles
         And I fill in 'Spotify' with 'https://open.spotify.com/artist/Jay-Z'
         And I click 'Update Profile'
         And I wait 1 second
-        Then I should see 'Profile has been successfullu updated'
+        Then I should see 'Profile has been successfully updated'
         And there should be a Artists Profile titled 'Jay-Z' in the Database
         And I should be redirected to the Artist page for 'Jay-Z'
 

--- a/features/artist_can_only_edit_own_profile.feature
+++ b/features/artist_can_only_edit_own_profile.feature
@@ -10,8 +10,8 @@ Feature: Artist can only edit own Artist profile
         | kanye@venue.se | artist |
         | jay@venue.se   | artist |
         And the following Performer exist
-        | name       | user           |
-        | Jay-Z      | jay@venue.se   |
+        | name  | user         |
+        | Jay-Z | jay@venue.se |
 
     Scenario: Jay can edit Jay's artist profile
         Given I am logged in as 'jay@venue.se'

--- a/features/artist_can_only_edit_own_profile.feature
+++ b/features/artist_can_only_edit_own_profile.feature
@@ -9,7 +9,7 @@ Feature: Artist can only edit own Artist profile
         | email          | role   |
         | kanye@venue.se | artist |
         | jay@venue.se   | artist |
-        And the following Performer exist
+        And the following Performer with name exist
         | name  | user         |
         | Jay-Z | jay@venue.se |
 

--- a/features/artist_can_only_edit_own_profile.feature
+++ b/features/artist_can_only_edit_own_profile.feature
@@ -1,12 +1,36 @@
 @javascript
 Feature: Artist can only edit own Artist profile
+    As a system owner
+    In order to relieve myself from keeping the artists profiles up to date
+    I would like to allow Artists to update their profile
 
     Background: 
         Given the following users exist
         | email          | role   |
         | kanye@venue.se | artist |
         | jay@venue.se   | artist |
-        And the following performers exist
-        | name       | user             |
-        | Kayne West | kanye@venue.se |
-        | Jay-Z      | jay@venue.se |
+        And the following Performer exist
+        | name       | user           |
+        | Jay-Z      | jay@venue.se   |
+
+    Scenario: Jay can edit Jay's artist profile
+        Given I am logged in as 'jay@venue.se'
+        And I am on the Performer page for 'Jay-Z'
+        And I click on 'Edit'
+        And I fill in 'Artist name' with 'Beyonce'
+        And I click 'Update Profile'
+        Then I should see 'Profile has been successfully updated'
+        And there should be a Artists Profile titled 'Beyonce' in the Database
+        And I should be redirected to the Artist page for 'Beyonce'
+
+    Scenario: Kayne can NOT edit Jay's artist profile 1
+        Given I am logged in as 'kanye@venue.se'
+        And I am on the Performer page for 'Jay-Z'
+        And I should NOT see 'Edit'
+
+    Scenario: Kayne can NOT edit Jay's artist profile 2
+        Given I am logged in as 'kanye@venue.se'
+        And I am on the Performer page for 'Jay-Z'
+        And I try to access the Edit Performer page for 'Jay-Z'
+        Then I should see 'Access denied'
+        And I should be redirected to the 'landing' page

--- a/features/artist_can_only_edit_own_profile.feature
+++ b/features/artist_can_only_edit_own_profile.feature
@@ -1,0 +1,12 @@
+@javascript
+Feature: Artist can only edit own Artist profile
+
+    Background: 
+        Given the following users exist
+        | email          | role   |
+        | kanye@venue.se | artist |
+        | jay@venue.se   | artist |
+        And the following performers exist
+        | name       | user             |
+        | Kayne West | kanye@venue.se |
+        | Jay-Z      | jay@venue.se |

--- a/features/artist_can_only_edit_own_profile.feature
+++ b/features/artist_can_only_edit_own_profile.feature
@@ -19,6 +19,7 @@ Feature: Artist can only edit own Artist profile
         And I click on 'Edit'
         And I fill in 'Artist name' with 'Beyonce'
         And I click 'Update Profile'
+        And I wait 1 second
         Then I should see 'Profile has been successfully updated'
         And there should be a Artists Profile titled 'Beyonce' in the Database
         And I should be redirected to the Artist page for 'Beyonce'

--- a/features/step_definitions/background_steps.rb
+++ b/features/step_definitions/background_steps.rb
@@ -10,7 +10,13 @@ Given("the following user(s) exist(s)") do |table|
     end
 end
 
-Given("the following Performer(s) exist(s)") do |table|
+Given("the following Performer exist") do |table|
+    table.hashes.each do |performer_hash|
+        create(:performer, performer_hash)
+    end
+end
+
+Given("the following Performer with name exist") do |table|
     table.hashes.each do |performer_hash|
         user = User.find_by(email: performer_hash[:user])
         create(:performer, performer_hash.except('user').merge(users: [user]))

--- a/features/step_definitions/background_steps.rb
+++ b/features/step_definitions/background_steps.rb
@@ -12,7 +12,8 @@ end
 
 Given("the following Performer(s) exist(s)") do |table|
     table.hashes.each do |performer_hash|
-        create(:performer, performer_hash)
+        user = User.find_by(email: performer_hash[:user])
+        create(:performer, performer_hash.except('user').merge(users: [user]))
     end
 end
 

--- a/spec/policies/performer_policy_spec.rb
+++ b/spec/policies/performer_policy_spec.rb
@@ -1,23 +1,33 @@
 require 'rails_helper'
- 
+
 RSpec.describe PerformerPolicy do
-    subject { described_class.new(user, performer) }
-    let(:performer) { create(:performer) }
-     
+    
+    let(:user_fan) { create(:user, role: 'fan') }
+    let(:user_artist1) { create(:user, email: 'artist1@venue.se', role: 'artist') }
+    let(:user_artist2) { create(:user, email: 'artist2@venue.se', role: 'artist') }
+    let(:user_admin) { create(:user, role: 'admin') }
+
+    let(:performer) { create(:performer, users: [user_artist1]) }
+
     context 'user is a fan' do
-        let(:user) { create(:user, role: 'fan') }
+        subject { described_class.new(user_fan, performer) }
         it { is_expected.to permit_actions [:index, :show] }
         it { is_expected.to forbid_actions [:create, :new, :update, :edit] }
     end
     
-    context 'user is an artist' do
-        let(:user) { create(:user, role: 'artist') }
+    context 'user is artist1 and own Performer and can edit' do
+        subject { described_class.new(user_artist1, performer) }
+        it { is_expected.to permit_actions [:index, :show, :create, :new, :update, :edit] }
+    end
+
+    context 'user is artist2 and can NOT edit Performer' do
+        subject { described_class.new(user_artist2, performer) }
         it { is_expected.to permit_actions [:index, :show, :create, :new] }
         it { is_expected.to forbid_actions [:update, :edit] }
     end
 
     context 'user is an admin' do
-        let(:user) { create(:user, role: 'admin') }
+        subject { described_class.new(user_admin, performer) }
         it { is_expected.to permit_actions [:index, :show, :create, :new, :update, :edit] }
     end
 end


### PR DESCRIPTION
## PT link
https://www.pivotaltracker.com/story/show/160449772

## User story
```
As a system owner
In order to relieve myself from keeping the artists profiles up to date
I would like to allow Artists to update their profile
```

## Tasks
- Allow Artists to update and edit Performer
- Restrict Artist to only be able to update their own profile

## No new gems or migrations
