### PR TITLE
Chore: Performer information for social media + displayed location

### DIFF
--- a/app/views/performers/show.html.haml
+++ b/app/views/performers/show.html.haml
@@ -5,7 +5,7 @@
         .mui-col-md-12
           .artist-picture{style: "background-image: url(#{rails_blob_path(@performer.profile_image) unless @performer.profile_image.attachment.nil? }"}
           %h1= @performer.name
-          .location Stockholm | Sweden
+          .location= @performer.city
           .genre
             - @performer.genres.map {|genre| genre.name}.each do |genre|
               %span= genre.humanize
@@ -35,15 +35,15 @@
           %p= @performer.description 
           %ul.artist-social-links
             %li
-              %a{href: "#"}
+              %a
                 = icon('fab', 'twitter')
                 = link_to "Twitter", @performer.twitter 
             %li
-              %a{href: "#"}
+              %a
                 = icon('fab', 'facebook')
                 = link_to "Facebook", @performer.facebook
             %li
-              %a{href: "#"}
+              %a
                 = icon('fab', 'instagram')
                 = link_to "Instagram", @performer.instagram
           .youtube-container

--- a/app/views/performers/show.html.haml
+++ b/app/views/performers/show.html.haml
@@ -37,15 +37,15 @@
             %li
               %a{href: "#"}
                 = icon('fab', 'twitter')
-                = @performer.twitter
+                = link_to "Twitter", @performer.twitter 
             %li
               %a{href: "#"}
                 = icon('fab', 'facebook')
-                = @performer.facebook
+                = link_to "Facebook", @performer.facebook
             %li
               %a{href: "#"}
                 = icon('fab', 'instagram')
-                = @performer.instagram
+                = link_to "Instagram", @performer.instagram
           .youtube-container
             %iframe{allow: "autoplay; encrypted-media", allowfullscreen: "", frameborder: "0", height: "315", src: "https://www.youtube.com/embed/-1uGdOHMXiI?rel=0&showinfo=0", width: "560"}
         .mui-col-md-12.mui-col-lg-4.spotify-container


### PR DESCRIPTION
## PT-link:
https://www.pivotaltracker.com/story/show/160365399

## Tasks
- Make social media-links work to 'shortcuts', displaying the name of the social media-platform as placeholder.
- Change location to display `@performer.city`