### PR TITLE
Display Spotify Artist-page on Artist Profile page

### DIFF
--- a/app/views/performers/_edit_form.html.haml
+++ b/app/views/performers/_edit_form.html.haml
@@ -46,7 +46,7 @@
           .mui-col-md-6
             .mui-textfield.mui-textfield--float-label   
               = form.text_field :spotify 
-              = form.label :spotify, 'Spotify-ID'
+              = form.label :spotify, 'Spotify URI'
         .form-group
           = form.submit 'Update Profile', class: 'form-submit'
           = button_tag 'Cancel', class: 'form-submit', onclick: 'cancelModal(event);' 

--- a/app/views/performers/_edit_form.html.haml
+++ b/app/views/performers/_edit_form.html.haml
@@ -46,7 +46,7 @@
           .mui-col-md-6
             .mui-textfield.mui-textfield--float-label   
               = form.text_field :spotify 
-              = form.label :spotify 
+              = form.label :spotify, 'Spotify-ID'
         .form-group
           = form.submit 'Update Profile', class: 'form-submit'
           = button_tag 'Cancel', class: 'form-submit', onclick: 'cancelModal(event);' 

--- a/app/views/performers/_form.html.haml
+++ b/app/views/performers/_form.html.haml
@@ -48,7 +48,7 @@
           .mui-col-md-6
             .mui-textfield.mui-textfield--float-label   
               = form.text_field :spotify
-              = form.label :spotify, 'Spotify-ID'
+              = form.label :spotify, 'Spotify URI'
         .mui-row
           .mui-col-lg-6
             .form-group

--- a/app/views/performers/_form.html.haml
+++ b/app/views/performers/_form.html.haml
@@ -47,8 +47,8 @@
               = form.label :website 
           .mui-col-md-6
             .mui-textfield.mui-textfield--float-label   
-              = form.text_field :spotify 
-              = form.label :spotify 
+              = form.text_field :spotify
+              = form.label :spotify, 'Spotify-ID'
         .mui-row
           .mui-col-lg-6
             .form-group

--- a/app/views/performers/show.html.haml
+++ b/app/views/performers/show.html.haml
@@ -49,7 +49,7 @@
           .youtube-container
             %iframe{allow: "autoplay; encrypted-media", allowfullscreen: "", frameborder: "0", height: "315", src: "https://www.youtube.com/embed/-1uGdOHMXiI?rel=0&showinfo=0", width: "560"}
         .mui-col-md-12.mui-col-lg-4.spotify-container
-          %iframe{allow: "encrypted-media", allowtransparency: "true", frameborder: "0", height: "380", src: "https://open.spotify.com/embed/user/ozze/playlist/3dxUfHVBNwwyNbsaTMYmPb", width: "300"}
+          %iframe{allow: "encrypted-media", allowtransparency: "true", frameborder: "0", height: "380", src: "https://open.spotify.com/embed/artist/#{@performer.spotify}'", width: "300"}
   .mui-container.artist-campaigns-container
     .mui-row
       .mui-col-lg-12

--- a/app/views/performers/show.html.haml
+++ b/app/views/performers/show.html.haml
@@ -49,7 +49,7 @@
           .youtube-container
             %iframe{allow: "autoplay; encrypted-media", allowfullscreen: "", frameborder: "0", height: "315", src: "https://www.youtube.com/embed/-1uGdOHMXiI?rel=0&showinfo=0", width: "560"}
         .mui-col-md-12.mui-col-lg-4.spotify-container
-          %iframe{allow: "encrypted-media", allowtransparency: "true", frameborder: "0", height: "380", src: "https://open.spotify.com/embed/artist/#{@performer.spotify}'", width: "300"}
+          %iframe{allow: "encrypted-media", allowtransparency: "true", frameborder: "0", height: "380", src: "https://open.spotify.com/embed/artist/#{@performer.spotify}".split("spotify:artist:").join, width: "300"}
   .mui-container.artist-campaigns-container
     .mui-row
       .mui-col-lg-12

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -136,8 +136,6 @@ Then("a ticket to {string} should be created for {string}") do |campaign_title, 
   expect(actual_ticket_campaign_ids).to include campaign.id
 end
 
-Then("I should see {string} in embed Spotify-player") do |expected_content|
-  within(iframe) do
-    expect(page).to have_content expected_content
-  end
+Then("I should see a embed Spotify-player") do
+    expect(page).to have_css('.spotify-container')
 end

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -135,3 +135,9 @@ Then("a ticket to {string} should be created for {string}") do |campaign_title, 
   actual_ticket_campaign_ids = user.event_tickets.map {|ticket| ticket.campaign.id }
   expect(actual_ticket_campaign_ids).to include campaign.id
 end
+
+Then("I should see {string} in embed Spotify-player") do |expected_content|
+  within(iframe) do
+    expect(page).to have_content expected_content
+  end
+end

--- a/features/user_can_see_spotify_iframe.feature
+++ b/features/user_can_see_spotify_iframe.feature
@@ -11,4 +11,4 @@ Feature: Display Spotify Artist-page on Artist Profile page
 
     Scenario:
         When I am on the Performer page for 'Oasis'
-        Then I should see 'Top tracks for Oasis' in embed Spotify-player
+        Then I should see a embed Spotify-player

--- a/features/user_can_see_spotify_iframe.feature
+++ b/features/user_can_see_spotify_iframe.feature
@@ -1,0 +1,14 @@
+@javascript
+Feature: Display Spotify Artist-page on Artist Profile page
+    As an Artist
+    In order to promote my/our music
+    I would like to display my Spotify Artist-page on my profile page
+
+    Background:
+        Given the following Performer exist
+        | name  | spotify                |
+        | Oasis | 2DaxqgrOhkeH0fpeiQq2f4 |
+
+    Scenario:
+        When I am on the Performer page for 'Oasis'
+        Then I should see 'Top tracks for Oasis' in embed Spotify-player


### PR DESCRIPTION
## PT-link:
https://www.pivotaltracker.com/story/show/160237251

## User story:
```
As an Artist
In order to promote my/our music
I would like to display my Spotify Artist-page on my profile page
```

## Tasks
- Make sure Artist Spotify-profile shows up in the `Spotify-iframe`

## View
![venue-gif-spotify](https://user-images.githubusercontent.com/33520974/46493401-86b76d00-c810-11e8-8e66-ca1bfcff58db.gif)