### PR TITLE
[FIX] Terms of Use and About

### DIFF
--- a/app/views/pages/about.html.haml
+++ b/app/views/pages/about.html.haml
@@ -1,6 +1,6 @@
 .mui-container-fluid
     .mui-row
-        .mui-col-md-4.mui-col-md-12.modal
+        .mui-col-md-12
             %br/
             %span.logo-venue
             .terms_of_use

--- a/app/views/pages/terms_of_use.html.haml
+++ b/app/views/pages/terms_of_use.html.haml
@@ -1,6 +1,6 @@
 .mui-container-fluid
     .mui-row
-        .mui-col-md-4.mui-col-md-12.modal
+        .mui-col-md-12
             %br/
             %span.logo-venue
             .terms_of_use{style: 'margin-bottom: 70px;'}

--- a/app/views/pages/terms_of_use.html.haml
+++ b/app/views/pages/terms_of_use.html.haml
@@ -3,7 +3,7 @@
         .mui-col-md-4.mui-col-md-12.modal
             %br/
             %span.logo-venue
-            .terms_of_use
+            .terms_of_use{style: 'margin-bottom: 70px;'}
                 %h1 Information about Venue
                 %br/
                 Venue.show is a service available on the Internet at venue.show, referred to in the terms of use as Venue.
@@ -201,8 +201,3 @@
                 war, labor conflicts, government regulations, injunctions or other public regulations, 
                 overload of the Internet, errors in other networks, and system failures or refusal of 
                 delivery from Venue's Suppliers.
-                %br/
-                %br/
-                %br/
-                %br/
-                %br/

--- a/app/views/pages/terms_of_use.html.haml
+++ b/app/views/pages/terms_of_use.html.haml
@@ -201,3 +201,8 @@
                 war, labor conflicts, government regulations, injunctions or other public regulations, 
                 overload of the Internet, errors in other networks, and system failures or refusal of 
                 delivery from Venue's Suppliers.
+                %br/
+                %br/
+                %br/
+                %br/
+                %br/


### PR DESCRIPTION
## Task

- Add space at bottom of `terms_of_use` so `footer` doesn't cover the text
- Fix `div` on line 3 to only display a `.mui-col-md-12` in both static-pages.